### PR TITLE
Add dat bypass workflow, incremental mode, and cluster DB processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,69 +6,67 @@ quantms has reanalyzed an extensive number of datasets with almost 1 billion MS/
 
 [spectrafuse](https://github.com/bigbio/spectrafuse) is a Nextflow workflow that performs incremental clustering of quantms data and is based on the tool [MaRaCluster](https://github.com/statisticalbiotechnology/maracluster).
 
-The workflow in a nutshell:
-
-![image](https://github.com/bigbio/spectrafuse/assets/52113/24a7c9ac-7287-421c-b8f1-6319764ed29c)
-
-Reference: https://github.com/bigbio/spectrafuse/blob/main/docs/algorithm.png
-
-The workflow is designed to be run in a high-performance computing environment, and it is built using [Nextflow](https://www.nextflow.io/). It uses Docker/Singularity containers making installation trivial and results highly reproducible. The [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html) implementation of this pipeline uses one container per process which makes it much easier to maintain and update software dependencies.
-
-## Table of Contents
-
-- [Workflow Overview](#workflow-overview)
-- [Input Requirements](#input-requirements)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Parameters](#parameters)
-- [Output Structure](#output-structure)
-- [Profiles](#profiles)
-- [Examples](#examples)
-
 ## Workflow Overview
 
-The spectrafuse workflow performs **two-phase clustering**:
+![SpectrafUSE Workflow](docs/images/spectrafuse_workflow.svg)
 
-### Phase 1: Project-Level Clustering
+The pipeline converts QPX parquet files directly into MaRaCluster's internal `.dat` binary format, bypassing MGF text files entirely. This **dat bypass** approach is 15x smaller than MGF (100 bytes/spectrum vs ~1.5 KB), making it feasible to cluster datasets with millions of PSMs on standard hardware.
 
-1. **MGF Converter** (`GENERATE_MGF_FILES`): Converts parquet files from each project into MGF format, organized by species, instrument, and charge state.
+The pipeline supports three modes:
 
-2. **Project-Level MaRaCluster** (`RUN_MARACLUSTER_PROJECT`): Clusters MGF files within each project, grouping by species, instrument, and charge. This produces project-specific clustering results.
+### Full Mode (default)
 
-3. **Project-Level MSP Generation** (`GENERATE_MSP_FORMAT_PROJECT`): Generates MSP format files for each project, creating consensus spectra from the project-level clusters.
+Parquet &rarr; `.dat` &rarr; MaRaCluster &rarr; Cluster DB
 
-4. **Project MSP Combination** (`COMBINE_PROJECT_MSP`): Combines all MSP files from a project (across all charge states and instruments) into a single project-level MSP file.
+1. **Parquet to Dat** (`PARQUET_TO_DAT`): Converts PSM parquet files directly to MaRaCluster's binary `.dat` format, optionally filtering by charge state. Replicates MaRaCluster's internal binning algorithm (`bin = floor(mz / 1.000508 + 0.32)`, top-40 peaks).
 
-### Phase 2: Global Clustering
+2. **MaRaCluster** (`RUN_MARACLUSTER_DAT`): Clusters spectra using the `-D` flag to read pre-existing `.dat` files, skipping MaRaCluster's own file conversion step.
 
-5. **Global MaRaCluster** (`RUN_MARACLUSTER_GLOBAL`): Clusters MGF files across **all projects**, grouping by species, instrument, and charge. This creates global clusters that span multiple projects.
+3. **Build Cluster DB** (`BUILD_CLUSTER_DB`): Generates `cluster_metadata.parquet` and `psm_cluster_membership.parquet` from MaRaCluster's clustering output and the scan-title mappings produced during dat conversion.
 
-6. **Global MSP Generation** (`GENERATE_MSP_FORMAT_GLOBAL`): Generates final MSP format files from the global clustering results, creating consensus spectra from clusters that include spectra from multiple projects.
+### Incremental Mode
+
+Adds new data to an existing cluster DB without re-clustering everything.
+
+1. **Extract Representatives** (`EXTRACT_REPRESENTATIVES`): Reads cluster metadata and writes one consensus spectrum per existing cluster.
+
+2. **Convert New Data** (`GENERATE_MGF_FILES`): Converts new project PSMs to charge-specific MGFs.
+
+3. **MaRaCluster** (`RUN_MARACLUSTER`): Clusters representatives + new data together. Representatives that land in the same new cluster as new spectra link those spectra to the existing cluster.
+
+4. **Merge Clusters** (`MERGE_INCREMENTAL`): Resolves cluster IDs (representative &rarr; original cluster mapping, multi-representative merges, fresh UUIDs for new-only clusters) and updates the cluster DB.
 
 ### Key Features
 
-- **Incremental Clustering**: Two-phase approach allows for project-specific libraries and global libraries
-- **Parallel Processing**: Projects are processed in parallel for efficiency
-- **Organized by Metadata**: Clustering is performed separately for each combination of species, instrument, and charge state
-- **Consensus Spectra**: Multiple strategies available for generating consensus spectra from clusters
+- **No MGF intermediate files**: The dat bypass eliminates MGF text inflation (12.8M PSMs = 1.3 GB `.dat` vs ~85 GB MGF)
+- **Incremental clustering**: Add new datasets without re-clustering existing data
+- **Parallel processing**: Projects and charge partitions are processed in parallel
+- **Partitioned by metadata**: Clustering is performed separately for each species/instrument/charge combination
+- **Consensus spectra**: Multiple strategies (best, bin, most, average) for generating consensus spectra from clusters
 
 ## Input Requirements
 
 The workflow requires:
 
-1. **Project Directory Structure**: A directory containing one or more project subdirectories. Each project directory should contain:
-   - **Parquet files** (`.parquet`): PSM data files generated by quantms. **Note**: The parquet files MUST contain the corresponding spectra for each identified peptide (mz_array and intensity_array columns).
-   - **SDRF files** (`.sdrf.tsv`): Sample and Data Relationship Format files containing metadata about the samples.
+1. **QPX Parquet files**: A directory containing one or more project subdirectories. Each project directory should contain the QPX file set:
 
-2. **Directory Structure**:
+   | File | Purpose |
+   |------|---------|
+   | `{id}.psm.parquet` | PSM spectra (mz_array, intensity_array, charge, sequence, etc.) |
+   | `{id}.run.parquet` | Run metadata (run_file_name, instrument, samples, enzymes) |
+   | `{id}.sample.parquet` | Sample metadata (organism, organism_part) |
+
+2. **Directory structure**:
    ```
    parquet_dir/
    ├── PXD004732/
-   │   ├── *.parquet
-   │   └── *.sdrf.tsv
+   │   ├── PXD004732.psm.parquet
+   │   ├── PXD004732.run.parquet
+   │   └── PXD004732.sample.parquet
    ├── PXD004733/
-   │   ├── *.parquet
-   │   └── *.sdrf.tsv
+   │   ├── PXD004733.psm.parquet
+   │   ├── PXD004733.run.parquet
+   │   └── PXD004733.sample.parquet
    └── ...
    ```
 
@@ -95,20 +93,23 @@ cd spectrafuse
 
 ## Usage
 
-### Basic Usage
+### Full Mode (dat bypass, default)
 
 ```bash
 nextflow run main.nf \
     --parquet_dir /path/to/projects \
+    --default_species "Homo sapiens" \
+    --default_instrument "Q Exactive HF" \
     -profile docker
 ```
 
-### With Custom Output Directory
+### Incremental Mode
 
 ```bash
 nextflow run main.nf \
-    --parquet_dir /path/to/projects \
-    --outdir ./results \
+    --parquet_dir /path/to/new_projects \
+    --mode incremental \
+    --existing_cluster_db /path/to/cluster_db \
     -profile docker
 ```
 
@@ -124,8 +125,7 @@ nextflow run main.nf \
 ### Test Run
 
 ```bash
-nextflow run main.nf \
-    -profile test,docker
+nextflow run main.nf -profile test,docker
 ```
 
 ## Parameters
@@ -134,7 +134,17 @@ nextflow run main.nf \
 
 | Parameter | Description | Example |
 |-----------|-------------|---------|
-| `--parquet_dir` | Directory containing project subdirectories with parquet and SDRF files | `/data/projects` |
+| `--parquet_dir` | Directory containing project subdirectories with QPX parquet files | `/data/projects` |
+
+### Pipeline Mode Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `--mode` | Pipeline mode: `full` or `incremental` | `full` |
+| `--existing_cluster_db` | Path to existing cluster DB (required for incremental mode) | `null` |
+| `--default_species` | Species label for cluster DB metadata | `null` |
+| `--default_instrument` | Instrument label for cluster DB metadata | `null` |
+| `--skip_instrument` | Cluster all instruments together (no instrument partitioning) | `false` |
 
 ### MaRaCluster Parameters
 
@@ -145,23 +155,11 @@ nextflow run main.nf \
 | `--cluster_threshold` | P-value threshold for MaRaCluster output file naming (e.g., `*_p30.tsv`) | `30` |
 | `--maracluster_verbose` | Enable verbose output from MaRaCluster | `false` |
 
-### MGF Generation Parameters
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `--mgf_verbose` | Enable verbose output from MGF generation | `true` |
-
-### MSP Format Generation Parameters
-
-These parameters control how consensus spectra are generated from clusters.
-
-#### Consensus Strategy
+### Consensus Strategy Parameters
 
 | Parameter | Description | Default | Options |
 |-----------|-------------|---------|---------|
 | `--strategytype` | Consensus spectrum generation method | `best` | `best`, `most`, `bin`, `average` |
-
-#### Strategy-Specific Parameters
 
 **For `most` method (Most Similar Spectrum):**
 | Parameter | Description | Default |
@@ -184,8 +182,8 @@ These parameters control how consensus spectra are generated from clusters.
 | `--diff_thresh` | Minimum distance between MS/MS peak clusters | `0.01` |
 | `--dyn_range` | Dynamic range to apply to output spectra | `1000` |
 | `--min_fraction` | Minimum fraction of cluster spectra where MS/MS peak is present (0.0-1.0) | `0.5` |
-| `--pepmass` | Peptide mass calculation method | `lower_median` | `naive_average`, `neutral_average`, `lower_median` |
-| `--msms_avg` | MS/MS averaging method | `weighted` | `naive`, `weighted` |
+| `--pepmass` | Peptide mass calculation method | `lower_median` |
+| `--msms_avg` | MS/MS averaging method | `weighted` |
 
 ### Output Parameters
 
@@ -204,42 +202,28 @@ These parameters control how consensus spectra are generated from clusters.
 
 ## Output Structure
 
-The workflow generates the following outputs in the `--outdir` directory:
+### Full Mode
 
 ```
 results/
-├── project_msp_files/          # Project-level MSP files (one per project)
-│   ├── PXD004732_project.msp
-│   └── PXD004733_project.msp
-├── maracluster_results/        # Global MaRaCluster clustering results
-│   └── ...
-├── msp_files/                  # Global MSP files (by species/instrument/charge)
-│   └── ...
-└── pipeline_info/              # Pipeline execution metadata
+├── cluster_db/                     # Cluster database (per charge partition)
+│   └── partition__charge{N}/
+│       ├── cluster_metadata.parquet       # One row per cluster (consensus spectrum, purity, member count)
+│       └── psm_cluster_membership.parquet # One row per PSM (USI, cluster_id, sequence, q-value)
+├── maracluster_results/            # MaRaCluster raw output
+│   └── clusters_p30.tsv
+└── pipeline_info/                  # Pipeline execution metadata
     ├── execution_report.html
     ├── execution_timeline.html
     ├── execution_trace.txt
     └── pipeline_dag.html
 ```
 
-### Project-Level MSP Files
+### Incremental Mode
 
-Located in `project_msp_files/`, these files contain all clusters from a single project, organized by charge state and instrument. Each file is named `{project_id}_project.msp`.
-
-### Global MSP Files
-
-Located in `msp_files/`, these files contain clusters that span multiple projects, organized by species, instrument, and charge state. The directory structure is:
-```
-msp_files/
-└── {species}/
-    └── {instrument}/
-        └── {charge}/
-            └── *.msp
-```
+Same structure as full mode, with updated cluster metadata and membership parquets that include both existing and new PSMs.
 
 ## Profiles
-
-Profiles are used to configure the execution environment and container engine.
 
 ### Container Engine Profiles
 
@@ -278,57 +262,6 @@ nextflow run main.nf -profile singularity
 nextflow run main.nf -profile test,docker
 ```
 
-## Examples
-
-### Example 1: Basic Run with Docker
-
-```bash
-nextflow run main.nf \
-    --parquet_dir /data/quantms_projects \
-    --outdir ./results \
-    -profile docker
-```
-
-### Example 2: Custom Consensus Strategy
-
-```bash
-nextflow run main.nf \
-    --parquet_dir /data/quantms_projects \
-    --strategytype average \
-    --min_fraction 0.6 \
-    --dyn_range 2000 \
-    -profile docker
-```
-
-### Example 3: Stricter Clustering Threshold
-
-```bash
-nextflow run main.nf \
-    --parquet_dir /data/quantms_projects \
-    --maracluster_pvalue_threshold -12.0 \
-    --cluster_threshold 40 \
-    -profile docker
-```
-
-### Example 4: Using Singularity on HPC
-
-```bash
-nextflow run main.nf \
-    --parquet_dir /data/quantms_projects \
-    --outdir /scratch/results \
-    -profile singularity
-```
-
-### Example 5: Resume Failed Run
-
-```bash
-# If a run fails or is interrupted, resume it:
-nextflow run main.nf \
-    --parquet_dir /data/quantms_projects \
-    -profile docker \
-    -resume
-```
-
 ## Consensus Spectrum Strategies
 
 The workflow supports four different strategies for generating consensus spectra from clusters:
@@ -360,11 +293,8 @@ Choose the strategy based on your use case:
 3. **Memory errors during clustering**
    - Solution: Increase `--max_memory` or reduce the number of parallel processes.
 
-4. **Missing SDRF files**
-   - Solution: Ensure each project directory contains at least one `.sdrf.tsv` file.
-
-5. **Missing spectra in parquet files**
-   - Solution: Ensure parquet files contain `mz_array` and `intensity_array` columns.
+4. **Missing QPX parquet files**
+   - Solution: Ensure each project directory contains `.psm.parquet`, `.run.parquet`, and `.sample.parquet` files.
 
 ### Getting Help
 

--- a/docs/images/spectrafuse_workflow.svg
+++ b/docs/images/spectrafuse_workflow.svg
@@ -1,0 +1,310 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1050" width="900" height="1050">
+  <defs>
+    <style>
+      .station-label {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 14px;
+        fill: #333;
+        font-weight: 600;
+      }
+      .station-sublabel {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 11px;
+        fill: #777;
+      }
+      .tool-badge text {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 8.5px;
+        font-weight: bold;
+        fill: #ffffff;
+      }
+      .legend-text {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 12px;
+        fill: #555;
+      }
+      .legend-title {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+        fill: #333;
+      }
+      .skip-label {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 10px;
+        font-style: italic;
+        fill: #999;
+      }
+      .mode-label {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 13px;
+        font-weight: bold;
+      }
+      .mode-sublabel {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 10px;
+        font-style: italic;
+      }
+      .section-title {
+        font-family: 'Helvetica Neue', Arial, sans-serif;
+        font-size: 11px;
+        font-weight: 600;
+        fill: #999;
+        letter-spacing: 1px;
+      }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="1050" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="450" y="35" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="bold" fill="#333">SpectrafUSE Pipeline Workflow</text>
+  <text x="450" y="52" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="11" fill="#888">Spectral clustering pipeline for PRIDE/MSnet proteomics reanalysis</text>
+
+  <!-- ==================== LEGEND (top right) ==================== -->
+  <g transform="translate(680, 70)">
+    <rect x="-10" y="-15" width="215" height="175" rx="6" fill="#f9f9f9" stroke="#e0e0e0" stroke-width="1"/>
+    <text x="0" y="0" class="legend-title">Legend</text>
+
+    <!-- Filled circle = Process -->
+    <circle cx="10" cy="22" r="6" fill="#666"/>
+    <text x="24" y="26" class="legend-text">Process / module</text>
+
+    <!-- Open circle = Output -->
+    <circle cx="10" cy="44" r="6" fill="none" stroke="#666" stroke-width="2"/>
+    <text x="24" y="48" class="legend-text">Output file</text>
+
+    <!-- Solid line -->
+    <line x1="2" y1="64" x2="18" y2="64" stroke="#666" stroke-width="4"/>
+    <text x="24" y="68" class="legend-text">Main flow</text>
+
+    <!-- Dashed line -->
+    <line x1="2" y1="86" x2="18" y2="86" stroke="#666" stroke-width="3" stroke-dasharray="6,3"/>
+    <text x="24" y="90" class="legend-text">Optional path</text>
+
+    <!-- Mode colors -->
+    <rect x="2" y="105" width="14" height="10" rx="2" fill="#00897B"/>
+    <text x="24" y="114" class="legend-text">Dat Bypass (recommended)</text>
+
+    <rect x="2" y="122" width="14" height="10" rx="2" fill="#43A047"/>
+    <text x="24" y="131" class="legend-text">Legacy MGF</text>
+
+    <rect x="2" y="139" width="14" height="10" rx="2" fill="#8E24AA"/>
+    <text x="24" y="148" class="legend-text">Incremental</text>
+  </g>
+
+  <!-- ==================== SHARED INPUT (Blue) ==================== -->
+  <!-- Input station -->
+  <circle cx="450" cy="100" r="9" fill="#1565C0"/>
+  <text x="450" y="96" text-anchor="end" dx="-18" class="station-label" fill="#1565C0">QPX Parquet Files</text>
+  <text x="450" y="112" text-anchor="end" dx="-18" class="station-sublabel">.psm.parquet + .run.parquet + .sample.parquet</text>
+
+  <!-- Line from input to router -->
+  <line x1="450" y1="109" x2="450" y2="155" stroke="#1565C0" stroke-width="5"/>
+
+  <!-- Mode Router Diamond -->
+  <polygon points="450,155 480,185 450,215 420,185" fill="none" stroke="#1565C0" stroke-width="2.5"/>
+  <text x="450" y="183" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="9" font-weight="bold" fill="#1565C0">--mode</text>
+  <text x="450" y="193" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="8" fill="#1565C0">--use_dat_bypass</text>
+
+  <!-- ==================== COLUMN HEADERS ==================== -->
+  <!-- Dat Bypass header -->
+  <text x="200" y="260" text-anchor="middle" class="mode-label" fill="#00897B">Dat Bypass Mode</text>
+  <text x="200" y="274" text-anchor="middle" class="mode-sublabel" fill="#00897B">(default, recommended)</text>
+
+  <!-- Legacy MGF header -->
+  <text x="450" y="260" text-anchor="middle" class="mode-label" fill="#43A047">Legacy MGF Mode</text>
+
+  <!-- Incremental header -->
+  <text x="700" y="260" text-anchor="middle" class="mode-label" fill="#8E24AA">Incremental Mode</text>
+
+  <!-- ==================== ROUTER TO COLUMNS ==================== -->
+  <!-- Router to Dat Bypass -->
+  <path d="M 435,200 Q 350,235 200,285" fill="none" stroke="#00897B" stroke-width="5"/>
+  <!-- Router to Legacy MGF -->
+  <line x1="450" y1="215" x2="450" y2="285" stroke="#43A047" stroke-width="5"/>
+  <!-- Router to Incremental -->
+  <path d="M 465,200 Q 550,235 700,285" fill="none" stroke="#8E24AA" stroke-width="5"/>
+
+  <!-- ==================== DAT BYPASS COLUMN (Teal) ==================== -->
+  <!-- Station 1: PARQUET_TO_DAT -->
+  <line x1="200" y1="295" x2="200" y2="390" stroke="#00897B" stroke-width="5"/>
+  <circle cx="200" cy="305" r="9" fill="#00897B"/>
+  <g class="tool-badge">
+    <rect x="100" y="295" width="85" height="16" rx="3" fill="#00897B"/>
+    <text x="142" y="306" text-anchor="middle">PARQUET_TO_DAT</text>
+  </g>
+  <text x="220" y="302" class="station-label">Parquet to .dat</text>
+  <text x="220" y="316" class="station-sublabel">15x smaller than MGF</text>
+
+  <!-- Station 2: Group by charge -->
+  <circle cx="200" cy="400" r="6" fill="#00897B"/>
+  <text x="220" y="397" class="station-sublabel" fill="#00897B" font-weight="600">Group by charge</text>
+
+  <line x1="200" y1="406" x2="200" y2="480" stroke="#00897B" stroke-width="5"/>
+
+  <!-- Station 3: RUN_MARACLUSTER_DAT -->
+  <circle cx="200" cy="490" r="9" fill="#00897B"/>
+  <g class="tool-badge">
+    <rect x="82" y="480" width="105" height="16" rx="3" fill="#00897B"/>
+    <text x="134" y="491" text-anchor="middle">RUN_MARACLUSTER_DAT</text>
+  </g>
+  <text x="220" y="487" class="station-label">MaRaCluster -D</text>
+  <text x="220" y="501" class="station-sublabel">reads .dat directly</text>
+
+  <line x1="200" y1="499" x2="200" y2="580" stroke="#00897B" stroke-width="5"/>
+
+  <!-- Station 4: BUILD_CLUSTER_DB -->
+  <circle cx="200" cy="590" r="9" fill="#00897B"/>
+  <g class="tool-badge">
+    <rect x="92" y="580" width="95" height="16" rx="3" fill="#00897B"/>
+    <text x="139" y="591" text-anchor="middle">BUILD_CLUSTER_DB</text>
+  </g>
+  <text x="220" y="587" class="station-label">Build Cluster DB</text>
+  <text x="220" y="601" class="station-sublabel">metadata + membership parquets</text>
+
+  <!-- ==================== LEGACY MGF COLUMN (Green) ==================== -->
+  <!-- Station 1: GENERATE_MGF_FILES -->
+  <line x1="450" y1="295" x2="450" y2="390" stroke="#43A047" stroke-width="5"/>
+  <circle cx="450" cy="305" r="9" fill="#43A047"/>
+  <g class="tool-badge">
+    <rect x="348" y="295" width="90" height="16" rx="3" fill="#43A047"/>
+    <text x="393" y="306" text-anchor="middle">GENERATE_MGF_FILES</text>
+  </g>
+  <text x="470" y="302" class="station-label">Parquet to MGF</text>
+  <text x="470" y="316" class="station-sublabel">grouped by species/instrument/charge</text>
+
+  <!-- Station 2: RUN_MARACLUSTER -->
+  <circle cx="450" cy="400" r="9" fill="#43A047"/>
+  <g class="tool-badge">
+    <rect x="355" y="390" width="80" height="16" rx="3" fill="#43A047"/>
+    <text x="395" y="401" text-anchor="middle">RUN_MARACLUSTER</text>
+  </g>
+  <text x="470" y="397" class="station-label">MaRaCluster</text>
+  <text x="470" y="411" class="station-sublabel">spectral clustering</text>
+
+  <!-- Branch: two parallel outputs from RUN_MARACLUSTER -->
+  <!-- Left branch to MSP -->
+  <path d="M 450,409 L 450,440 L 390,470" stroke="#43A047" stroke-width="5" fill="none"/>
+  <!-- Right branch to Cluster Parquet -->
+  <path d="M 450,409 L 450,440 L 510,470" stroke="#43A047" stroke-width="5" fill="none"/>
+
+  <!-- Station 3a: GENERATE_MSP_FORMAT -->
+  <line x1="390" y1="470" x2="390" y2="490" stroke="#43A047" stroke-width="5"/>
+  <circle cx="390" cy="490" r="9" fill="#43A047"/>
+  <g class="tool-badge">
+    <rect x="278" y="480" width="100" height="16" rx="3" fill="#43A047"/>
+    <text x="328" y="491" text-anchor="middle">GENERATE_MSP_FORMAT</text>
+  </g>
+  <text x="310" y="510" class="station-label">Consensus MSP</text>
+  <text x="310" y="524" class="station-sublabel">best/bin consensus spectra</text>
+
+  <!-- Station 3b: GENERATE_CLUSTER_PARQUET -->
+  <line x1="510" y1="470" x2="510" y2="490" stroke="#43A047" stroke-width="5"/>
+  <circle cx="510" cy="490" r="9" fill="#43A047"/>
+  <g class="tool-badge">
+    <rect x="524" y="480" width="120" height="16" rx="3" fill="#43A047"/>
+    <text x="584" y="491" text-anchor="middle">GENERATE_CLUSTER_PARQUET</text>
+  </g>
+  <text x="530" y="510" class="station-label">Cluster Parquet</text>
+  <text x="530" y="524" class="station-sublabel">cluster membership DB</text>
+
+  <!-- Merge back -->
+  <path d="M 390,499 L 390,550 L 450,580" stroke="#43A047" stroke-width="5" fill="none"/>
+  <path d="M 510,499 L 510,550 L 450,580" stroke="#43A047" stroke-width="5" fill="none"/>
+
+  <!-- ==================== INCREMENTAL COLUMN (Purple) ==================== -->
+  <!-- Split into two parallel inputs -->
+  <!-- Left rail: EXTRACT_REPRESENTATIVES -->
+  <path d="M 700,285 L 660,310" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <line x1="660" y1="310" x2="660" y2="390" stroke="#8E24AA" stroke-width="5"/>
+  <circle cx="660" cy="320" r="9" fill="#8E24AA"/>
+  <g class="tool-badge">
+    <rect x="540" y="310" width="108" height="16" rx="3" fill="#8E24AA"/>
+    <text x="594" y="321" text-anchor="middle">EXTRACT_REPRESENTATIVES</text>
+  </g>
+  <text x="608" y="338" class="station-label" text-anchor="end">Extract Reps</text>
+  <text x="608" y="352" class="station-sublabel" text-anchor="end">one spectrum per existing cluster</text>
+
+  <!-- Right rail: GENERATE_MGF_FILES (new data) -->
+  <path d="M 700,285 L 740,310" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <line x1="740" y1="310" x2="740" y2="390" stroke="#8E24AA" stroke-width="5"/>
+  <circle cx="740" cy="320" r="9" fill="#8E24AA"/>
+  <g class="tool-badge">
+    <rect x="755" y="310" width="90" height="16" rx="3" fill="#8E24AA"/>
+    <text x="800" y="321" text-anchor="middle">GENERATE_MGF_FILES</text>
+  </g>
+  <text x="755" y="338" class="station-label">New Data to MGF</text>
+  <text x="755" y="352" class="station-sublabel">convert new project PSMs</text>
+
+  <!-- Merge rails -->
+  <path d="M 660,390 L 700,420" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <path d="M 740,390 L 700,420" stroke="#8E24AA" stroke-width="5" fill="none"/>
+
+  <line x1="700" y1="420" x2="700" y2="490" stroke="#8E24AA" stroke-width="5"/>
+
+  <!-- Station 3: RUN_MARACLUSTER -->
+  <circle cx="700" cy="490" r="9" fill="#8E24AA"/>
+  <g class="tool-badge">
+    <rect x="605" y="480" width="80" height="16" rx="3" fill="#8E24AA"/>
+    <text x="645" y="491" text-anchor="middle">RUN_MARACLUSTER</text>
+  </g>
+  <text x="720" y="487" class="station-label">MaRaCluster</text>
+  <text x="720" y="501" class="station-sublabel">reps + new data together</text>
+
+  <line x1="700" y1="499" x2="700" y2="580" stroke="#8E24AA" stroke-width="5"/>
+
+  <!-- Station 4: MERGE_INCREMENTAL -->
+  <circle cx="700" cy="590" r="9" fill="#8E24AA"/>
+  <g class="tool-badge">
+    <rect x="592" y="580" width="95" height="16" rx="3" fill="#8E24AA"/>
+    <text x="639" y="591" text-anchor="middle">MERGE_INCREMENTAL</text>
+  </g>
+  <text x="720" y="587" class="station-label">Merge Clusters</text>
+  <text x="720" y="601" class="station-sublabel">resolve IDs, update membership</text>
+
+  <!-- ==================== EXISTING CLUSTER DB INPUT (Purple, dashed) ==================== -->
+  <circle cx="830" cy="260" r="8" fill="none" stroke="#8E24AA" stroke-width="2"/>
+  <text x="830" y="255" text-anchor="middle" class="station-sublabel" fill="#8E24AA">Existing</text>
+  <text x="830" y="245" text-anchor="middle" class="station-sublabel" fill="#8E24AA">Cluster DB</text>
+  <line x1="820" y1="268" x2="670" y2="312" stroke="#8E24AA" stroke-width="3" stroke-dasharray="6,3"/>
+
+  <!-- ==================== SHARED OUTPUTS (Orange) ==================== -->
+  <text x="450" y="680" text-anchor="middle" class="section-title" fill="#999">OUTPUTS</text>
+
+  <!-- Convergence lines to outputs -->
+  <!-- Dat Bypass to Cluster DB -->
+  <path d="M 200,599 L 200,720 L 310,740" stroke="#00897B" stroke-width="5" fill="none"/>
+  <!-- Legacy MGF to Cluster DB -->
+  <path d="M 450,580 L 450,700 L 390,740" stroke="#43A047" stroke-width="5" fill="none"/>
+  <!-- Incremental to Cluster DB -->
+  <path d="M 700,599 L 700,720 L 440,740" stroke="#8E24AA" stroke-width="5" fill="none"/>
+
+  <!-- Output 1: Cluster DB -->
+  <circle cx="370" cy="750" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+  <text x="390" y="747" class="station-label" fill="#F57C00">Cluster DB</text>
+  <text x="390" y="763" class="station-sublabel">cluster_metadata.parquet + psm_cluster_membership.parquet</text>
+
+  <!-- Output 2: MaRaCluster Results -->
+  <!-- Lines from all three modes -->
+  <path d="M 200,720 L 310,810" stroke="#00897B" stroke-width="5" fill="none"/>
+  <path d="M 450,700 L 390,810" stroke="#43A047" stroke-width="5" fill="none"/>
+  <path d="M 700,720 L 440,810" stroke="#8E24AA" stroke-width="5" fill="none"/>
+
+  <circle cx="370" cy="820" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+  <text x="390" y="817" class="station-label" fill="#F57C00">MaRaCluster Results</text>
+  <text x="390" y="833" class="station-sublabel">clusters_pN.tsv</text>
+
+  <!-- Output 3: Consensus MSP (Legacy MGF only) -->
+  <path d="M 450,700 L 450,880 L 410,900" stroke="#43A047" stroke-width="3" stroke-dasharray="6,3" fill="none"/>
+  <circle cx="370" cy="900" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+  <text x="390" y="897" class="station-label" fill="#F57C00">Consensus MSP</text>
+  <text x="390" y="913" class="station-sublabel">.msp spectral library</text>
+  <text x="390" y="928" class="skip-label">(Legacy MGF mode only)</text>
+
+  <!-- ==================== FOOTER ==================== -->
+  <text x="450" y="980" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="10" fill="#bbb">SpectrafUSE v0.0.4 -- Nextflow DSL2 Workflow</text>
+  <text x="450" y="995" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="9" fill="#ccc">dat bypass eliminates MGF text inflation (15x size reduction, 12.8M PSMs = 1.3 GB .dat vs 85 GB MGF)</text>
+
+</svg>

--- a/e2e.config
+++ b/e2e.config
@@ -1,0 +1,30 @@
+/*
+ * End-to-end test configuration for spectrafuse pipeline.
+ * Uses local pyspectrafuse:local Docker image with bug fixes.
+ * Test data: PXD014877 (Mycoplasmen, 3608 PSMs, QPX format)
+ */
+
+params {
+    parquet_dir = '/srv/data/spectrafuse/test_input/pxd014877'
+    outdir      = '/srv/data/spectrafuse/test_output/nf_pxd014877'
+    max_memory  = '8.GB'
+    max_cpus    = 4
+    max_time    = '2.h'
+    mgf_verbose = false
+}
+
+process {
+    // Override all pyspectrafuse modules to use local image with bug fixes
+    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+}
+
+// Running as root — no user mapping needed
+docker.runOptions = ''
+
+// Override default quay.io registry — local images don't need a registry prefix
+docker.registry = ''

--- a/incremental_quality.config
+++ b/incremental_quality.config
@@ -1,0 +1,40 @@
+/*
+ * Phase 0: Incremental Clustering Quality Validation
+ *
+ * Step 1 — Baseline: cluster PXD000865-1M (1M PSMs, Trypsin) alone
+ *   cd /srv/data/spectrafuse/repo-clone
+ *   nextflow run main.nf -c incremental_quality.config -profile docker \
+ *       --outdir /srv/data/spectrafuse/test_output/phase0_baseline
+ *
+ * Step 2 — Incremental: add PXD000865-Chymotrypsin (149K) using incremental CLI
+ * Step 3 — Incremental: add PXD000865-LysC (528K) using incremental CLI
+ * Step 4 — Compare: check false merges across enzymes
+ */
+
+params {
+    parquet_dir = '/srv/data/spectrafuse/test_input/incremental_quality'
+    outdir      = '/srv/data/spectrafuse/test_output/phase0_baseline'
+    max_memory  = '8.GB'
+    max_cpus    = 4
+    max_time    = '6.h'
+    mgf_verbose = false
+
+    // MaRaCluster settings
+    cluster_threshold     = 30
+    maracluster_pvalue_threshold = -10.0
+
+    // Use best strategy (only viable at scale)
+    strategytype = 'best'
+}
+
+process {
+    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+}
+
+docker.runOptions = ''
+docker.registry = ''

--- a/main.nf
+++ b/main.nf
@@ -32,9 +32,8 @@ workflow BIGBIO_SPECTRAFUSE {
     SPECTRAFUSE(ch_projects, ch_parquet_dir)
 
     emit:
-    project_msp_files   = SPECTRAFUSE.out.project_msp_files
     maracluster_results = SPECTRAFUSE.out.maracluster_results
-    msp_files           = SPECTRAFUSE.out.msp_files
+    cluster_parquet     = SPECTRAFUSE.out.cluster_parquet
     versions            = SPECTRAFUSE.out.versions
 }
 
@@ -54,6 +53,10 @@ workflow {
     // Validate input parameters
     if (!params.parquet_dir) {
         error "Please provide a folder containing the files that will be clustered (--parquet_dir)"
+    }
+
+    if (params.mode == 'incremental' && !params.existing_cluster_db) {
+        error "Incremental mode requires --existing_cluster_db pointing to the existing cluster DB directory"
     }
 
     // Create channels for all items to be clustered

--- a/modules/local/maracluster/run_maracluster_dat/main.nf
+++ b/modules/local/maracluster/run_maracluster_dat/main.nf
@@ -1,0 +1,69 @@
+process RUN_MARACLUSTER_DAT {
+    label 'process_medium'
+    tag { meta.id }
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://containers.biocontainers.pro/s3/SingImgsRepo/maracluster/1.04.1_cv1/maracluster_1.04.1_cv1.sif' :
+        'docker.io/biocontainers/maracluster:1.04.1_cv1' }"
+
+    input:
+    tuple val(meta), path(dat_files), path(scan_titles)
+
+    output:
+    tuple val(meta), path("maracluster_output/*_p${params.cluster_threshold}.tsv"), emit: maracluster_results
+    tuple val(meta), path("scan_titles/*"),                                          emit: scan_titles_out
+    path "versions.yml",                                                             emit: versions
+
+    script:
+    def verbose = params.maracluster_verbose ? "-v 3" : "-v 0"
+    def args = task.ext.args ?: ''
+
+    """
+    # Create dummy MGF files matching .dat basenames (MaRaCluster batch requires MGF list)
+    mkdir -p dummy_mgf dat_dir scan_titles
+
+    for dat in ${dat_files}; do
+        if [[ "\$dat" == *.scan_info.dat ]]; then
+            cp "\$dat" dat_dir/
+            continue
+        fi
+        # Only process .dat files (not scan_info.dat)
+        basename=\$(basename "\$dat" .dat)
+        # Create minimal dummy MGF
+        echo -e "BEGIN IONS\\nTITLE=dummy\\nPEPMASS=500.0\\nCHARGE=2+\\n100 1000\\nEND IONS" > "dummy_mgf/\${basename}.mgf"
+        cp "\$dat" dat_dir/
+    done
+
+    # Copy scan_titles for downstream cluster DB building
+    for st in ${scan_titles}; do
+        cp "\$st" scan_titles/
+    done
+
+    # Build batch file with dummy MGF paths
+    ls dummy_mgf/*.mgf | sed 's|^|./|' > files_list.txt
+
+    # Run MaRaCluster with -D flag to use pre-existing .dat files
+    maracluster batch -b files_list.txt -t ${params.maracluster_pvalue_threshold} \
+        -p '${params.maracluster_precursor_tolerance}' \
+        -D dat_dir \
+        ${verbose} ${args}
+
+    # Verify output
+    if [ ! -d maracluster_output ]; then
+        echo "ERROR: MaRaCluster did not create maracluster_output directory"
+        exit 1
+    fi
+
+    output_count=\$(find maracluster_output -name "*_p${params.cluster_threshold}.tsv" -type f | wc -l)
+    if [ "\$output_count" -eq 0 ]; then
+        echo "ERROR: No output files matching *_p${params.cluster_threshold}.tsv"
+        ls -la maracluster_output/
+        exit 1
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        maracluster: \$(maracluster --version 2>&1 | head -n 1 | sed 's/.*version //g' || echo "1.04.1")
+    END_VERSIONS
+    """
+}

--- a/modules/local/pyspectrafuse/build_cluster_db/main.nf
+++ b/modules/local/pyspectrafuse/build_cluster_db/main.nf
@@ -1,0 +1,53 @@
+process BUILD_CLUSTER_DB {
+    label 'process_medium'
+    tag { meta.id }
+    publishDir "${params.outdir}/cluster_db", mode: params.publish_dir_mode, pattern: "cluster_db/*.parquet"
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'docker://ghcr.io/bigbio/pyspectrafuse:0.0.4' :
+        'ghcr.io/bigbio/pyspectrafuse:0.0.4' }"
+
+    containerOptions = workflow.containerEngine == 'singularity' ?
+        '--env NUMBA_DISABLE_JIT=1 --env NUMBA_DISABLE_CACHING=1 --env NUMBA_CACHE_DIR=/tmp' :
+        '-e NUMBA_DISABLE_JIT=1 -e NUMBA_DISABLE_CACHING=1 -e NUMBA_CACHE_DIR=/tmp'
+
+    input:
+    tuple val(meta), path(cluster_tsv), path(scan_titles), path(parquet_dirs)
+
+    output:
+    tuple val(meta), path("cluster_db/cluster_metadata.parquet"),         emit: cluster_metadata
+    tuple val(meta), path("cluster_db/psm_cluster_membership.parquet"),   emit: psm_membership
+    path "versions.yml",                                                   emit: versions
+
+    shell:
+    // Build --scan_titles and --parquet_dir and --dataset_name args from the lists
+    def titles_args = scan_titles.collect { "--scan_titles ${it}" }.join(' ')
+    def dir_args = parquet_dirs.collect { "--parquet_dir ${it}" }.join(' ')
+    def name_args = parquet_dirs.collect { "--dataset_name ${it.baseName}" }.join(' ')
+    def args = task.ext.args ?: ''
+
+    """
+    export NUMBA_DISABLE_JIT=1
+    export NUMBA_DISABLE_CACHING=1
+    export NUMBA_CACHE_DIR=/tmp
+
+    pyspectrafuse build-cluster-db \
+        --cluster_tsv !{cluster_tsv} \
+        !{titles_args} \
+        !{dir_args} \
+        !{name_args} \
+        --species "${meta.species}" \
+        --instrument "${meta.instrument}" \
+        --charge "${meta.charge}" \
+        --method_type "${params.strategytype}" \
+        --output_dir cluster_db \
+        ${args}
+
+    PYSPECTRAFUSE_VERSION=\$(pyspectrafuse --version 2>&1 | sed 's/.*version //g' || echo "0.0.4")
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pyspectrafuse: \${PYSPECTRAFUSE_VERSION}
+    END_VERSIONS
+    """
+}

--- a/modules/local/pyspectrafuse/combine_project_msp/main.nf
+++ b/modules/local/pyspectrafuse/combine_project_msp/main.nf
@@ -1,6 +1,7 @@
 process COMBINE_PROJECT_MSP {
     label 'process_low'
     tag { meta.id }
+    publishDir "${params.outdir}/project_msp_files", mode: params.publish_dir_mode, pattern: "*.msp"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'docker://ghcr.io/bigbio/pyspectrafuse:0.0.2' :

--- a/modules/local/pyspectrafuse/extract_representatives/main.nf
+++ b/modules/local/pyspectrafuse/extract_representatives/main.nf
@@ -1,0 +1,42 @@
+process EXTRACT_REPRESENTATIVES {
+    label 'process_low'
+    tag { meta.id }
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'docker://ghcr.io/bigbio/pyspectrafuse:0.0.3' :
+        'ghcr.io/bigbio/pyspectrafuse:0.0.3' }"
+
+    containerOptions = workflow.containerEngine == 'singularity' ?
+        '--env NUMBA_DISABLE_JIT=1 --env NUMBA_DISABLE_CACHING=1 --env NUMBA_CACHE_DIR=/tmp' :
+        '-e NUMBA_DISABLE_JIT=1 -e NUMBA_DISABLE_CACHING=1 -e NUMBA_CACHE_DIR=/tmp'
+
+    input:
+    tuple val(meta), path(cluster_metadata_parquet)
+
+    output:
+    tuple val(meta), path("representatives/*.mgf"), emit: representative_mgf
+    path "versions.yml", emit: versions
+
+    shell:
+    def args = task.ext.args ?: ''
+
+    """
+    export NUMBA_DISABLE_JIT=1
+    export NUMBA_DISABLE_CACHING=1
+    export NUMBA_CACHE_DIR=/tmp
+
+    mkdir -p representatives
+
+    pyspectrafuse incremental extract-reps \
+        --cluster_metadata !{cluster_metadata_parquet} \
+        --output_mgf representatives/!{meta.id}_representatives.mgf \
+        ${args}
+
+    PYSPECTRAFUSE_VERSION=\$(pyspectrafuse --version 2>&1 | sed 's/.*version //g' || echo "0.0.3")
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pyspectrafuse: \${PYSPECTRAFUSE_VERSION}
+    END_VERSIONS
+    """
+}

--- a/modules/local/pyspectrafuse/generate_cluster_parquet/main.nf
+++ b/modules/local/pyspectrafuse/generate_cluster_parquet/main.nf
@@ -1,16 +1,14 @@
-process GENERATE_MSP_FORMAT {
+process GENERATE_CLUSTER_PARQUET {
     label 'process_low'
     tag { meta.id }
-    publishDir "${params.outdir}/msp_files", mode: params.publish_dir_mode, pattern: "**/*.msp"
+    publishDir "${params.outdir}/cluster_parquet", mode: params.publish_dir_mode, pattern: "cluster_db/**/*.parquet"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/bigbio/pyspectrafuse:0.0.2' :
-        'ghcr.io/bigbio/pyspectrafuse:0.0.2' }"
-    
-    // Additional environment variables for Numba in containers
-    // Disable JIT and caching to prevent issues when running as non-root user
-    containerOptions = workflow.containerEngine == 'singularity' ? 
-        '--env NUMBA_DISABLE_JIT=1 --env NUMBA_DISABLE_CACHING=1 --env NUMBA_CACHE_DIR=/tmp' : 
+        'docker://ghcr.io/bigbio/pyspectrafuse:0.0.3' :
+        'ghcr.io/bigbio/pyspectrafuse:0.0.3' }"
+
+    containerOptions = workflow.containerEngine == 'singularity' ?
+        '--env NUMBA_DISABLE_JIT=1 --env NUMBA_DISABLE_CACHING=1 --env NUMBA_CACHE_DIR=/tmp' :
         '-e NUMBA_DISABLE_JIT=1 -e NUMBA_DISABLE_CACHING=1 -e NUMBA_CACHE_DIR=/tmp'
 
     input:
@@ -18,28 +16,25 @@ process GENERATE_MSP_FORMAT {
     tuple val(meta), path(cluster_tsv_file)
 
     output:
-    path "**/*.msp", emit: msp_files, optional: true
+    path "cluster_db/**/*.parquet", emit: cluster_parquet_files
     path "versions.yml", emit: versions
 
     shell:
-    def verbose = params.mgf_verbose ? "-v" : ""
     def args = task.ext.args ?: ''
 
     """
-    # Disable Numba JIT and caching to prevent container issues when running as non-root user
     export NUMBA_DISABLE_JIT=1
     export NUMBA_DISABLE_CACHING=1
     export NUMBA_CACHE_DIR=/tmp
-    
-    # Run MSP format generation using pyspectrafuse msp from the pyspectrafuse container
-    # Use !{} syntax for safe shell escaping to prevent command injection
-    pyspectrafuse msp \
+
+    pyspectrafuse cluster-parquet \
         --parquet_dir !{parquet_dir} \
         --method_type "${params.strategytype}" \
         --cluster_tsv_file !{cluster_tsv_file} \
         --species "${meta.species}" \
         --instrument "${meta.instrument}" \
         --charge "${meta.charge}" \
+        --output_dir cluster_db \
         --sim "${params.sim}" \
         --fragment_mz_tolerance "${params.fragment_mz_tolerance}" \
         --min_mz "${params.min_mz}" \
@@ -52,10 +47,9 @@ process GENERATE_MSP_FORMAT {
         --min_fraction "${params.min_fraction}" \
         --pepmass "${params.pepmass}" \
         --msms_avg "${params.msms_avg}" \
-        ${verbose} ${args}
+        ${args}
 
-    # Get pyspectrafuse version dynamically
-    PYSPECTRAFUSE_VERSION=\$(pyspectrafuse --version 2>&1 | sed 's/.*version //g' || echo "0.0.2")
+    PYSPECTRAFUSE_VERSION=\$(pyspectrafuse --version 2>&1 | sed 's/.*version //g' || echo "0.0.3")
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -63,4 +57,3 @@ process GENERATE_MSP_FORMAT {
     END_VERSIONS
     """
 }
-

--- a/modules/local/pyspectrafuse/generate_cluster_parquet/meta.yml
+++ b/modules/local/pyspectrafuse/generate_cluster_parquet/meta.yml
@@ -1,0 +1,33 @@
+name: generate_cluster_parquet
+description: Generate Parquet database files (cluster_metadata + psm_cluster_membership) from MaRaCluster results
+keywords:
+  - clustering
+  - parquet
+  - spectral library
+  - proteomics
+tools:
+  - pyspectrafuse:
+      description: Python library for spectral clustering and consensus spectrum generation
+      homepage: https://github.com/bigbio/pyspectrafuse
+      documentation: https://github.com/bigbio/pyspectrafuse
+      licence: ["Apache-2.0"]
+input:
+  - parquet_dir:
+      type: directory
+      description: Base directory containing project parquet and SDRF files
+  - meta:
+      type: map
+      description: Groovy Map containing sample information (species, instrument, charge)
+  - cluster_tsv_file:
+      type: file
+      description: MaRaCluster output TSV file with cluster assignments
+      pattern: "*.tsv"
+output:
+  - cluster_parquet_files:
+      type: file
+      description: Parquet files with cluster metadata and PSM membership
+      pattern: "cluster_db/**/*.parquet"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"

--- a/modules/local/pyspectrafuse/merge_incremental/main.nf
+++ b/modules/local/pyspectrafuse/merge_incremental/main.nf
@@ -1,0 +1,49 @@
+process MERGE_INCREMENTAL {
+    label 'process_low'
+    tag { meta.id }
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'docker://ghcr.io/bigbio/pyspectrafuse:0.0.3' :
+        'ghcr.io/bigbio/pyspectrafuse:0.0.3' }"
+
+    containerOptions = workflow.containerEngine == 'singularity' ?
+        '--env NUMBA_DISABLE_JIT=1 --env NUMBA_DISABLE_CACHING=1 --env NUMBA_CACHE_DIR=/tmp' :
+        '-e NUMBA_DISABLE_JIT=1 -e NUMBA_DISABLE_CACHING=1 -e NUMBA_CACHE_DIR=/tmp'
+
+    input:
+    path parquet_dir
+    tuple val(meta), path(cluster_tsv_file), path(rep_mgf), path(existing_metadata), path(existing_membership)
+
+    output:
+    path "cluster_db/**/*.parquet", emit: cluster_parquet_files
+    path "versions.yml", emit: versions
+
+    shell:
+    def args = task.ext.args ?: ''
+
+    """
+    export NUMBA_DISABLE_JIT=1
+    export NUMBA_DISABLE_CACHING=1
+    export NUMBA_CACHE_DIR=/tmp
+
+    pyspectrafuse incremental merge-clusters \
+        --cluster_tsv !{cluster_tsv_file} \
+        --rep_mgf !{rep_mgf} \
+        --existing_metadata !{existing_metadata} \
+        --existing_membership !{existing_membership} \
+        --new_parquet_dir !{parquet_dir} \
+        --species "${meta.species}" \
+        --instrument "${meta.instrument}" \
+        --charge "${meta.charge}" \
+        --method_type "${params.strategytype}" \
+        --output_dir cluster_db/${meta.species}/${meta.instrument}/${meta.charge} \
+        ${args}
+
+    PYSPECTRAFUSE_VERSION=\$(pyspectrafuse --version 2>&1 | sed 's/.*version //g' || echo "0.0.3")
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pyspectrafuse: \${PYSPECTRAFUSE_VERSION}
+    END_VERSIONS
+    """
+}

--- a/modules/local/pyspectrafuse/parquet_to_dat/main.nf
+++ b/modules/local/pyspectrafuse/parquet_to_dat/main.nf
@@ -1,0 +1,45 @@
+process PARQUET_TO_DAT {
+    label 'process_low'
+    tag { meta.id }
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'docker://ghcr.io/bigbio/pyspectrafuse:0.0.4' :
+        'ghcr.io/bigbio/pyspectrafuse:0.0.4' }"
+
+    containerOptions = workflow.containerEngine == 'singularity' ?
+        '--env NUMBA_DISABLE_JIT=1 --env NUMBA_DISABLE_CACHING=1 --env NUMBA_CACHE_DIR=/tmp' :
+        '-e NUMBA_DISABLE_JIT=1 -e NUMBA_DISABLE_CACHING=1 -e NUMBA_CACHE_DIR=/tmp'
+
+    input:
+    tuple val(meta), path(project_dir)
+
+    output:
+    tuple val(meta), path("dat_output/*.dat"),              emit: dat_files
+    tuple val(meta), path("dat_output/*.scan_info.dat"),    emit: scaninfo_files
+    tuple val(meta), path("dat_output/*.scan_titles.txt"),  emit: scan_titles
+    path "versions.yml",                                    emit: versions
+
+    script:
+    def args = task.ext.args ?: ''
+    def charge_opt = meta.charge_int ? "-c ${meta.charge_int}" : ""
+
+    """
+    export NUMBA_DISABLE_JIT=1
+    export NUMBA_DISABLE_CACHING=1
+    export NUMBA_CACHE_DIR=/tmp
+
+    pyspectrafuse convert-dat \
+        -p ${project_dir} \
+        -o dat_output \
+        ${charge_opt} \
+        --file_idx ${meta.file_idx ?: 0} \
+        ${args}
+
+    PYSPECTRAFUSE_VERSION=\$(pyspectrafuse --version 2>&1 | sed 's/.*version //g' || echo "0.0.4")
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pyspectrafuse: \${PYSPECTRAFUSE_VERSION}
+    END_VERSIONS
+    """
+}

--- a/modules/local/quantmsio2mgf/generate_mgf_files/main.nf
+++ b/modules/local/quantmsio2mgf/generate_mgf_files/main.nf
@@ -31,7 +31,7 @@ process GENERATE_MGF_FILES {
     
     # Run the conversion using pyspectrafuse convert-mgf from the pyspectrafuse container
     # The script creates mgf_output directory inside the parquet_dir (file_input)
-    pyspectrafuse convert-mgf --parquet_dir ${file_input} ${verbose} ${args}
+    pyspectrafuse convert-mgf --parquet_dir ${file_input} ${verbose} ${args} ${params.skip_instrument ? '--skip_instrument' : ''}
 
     # Get pyspectrafuse version dynamically
     PYSPECTRAFUSE_VERSION=\$(pyspectrafuse --version 2>&1 | sed 's/.*version //g' || echo "0.0.2")

--- a/multi_project.config
+++ b/multi_project.config
@@ -1,0 +1,27 @@
+/*
+ * Multi-project clustering configuration.
+ * 5 Homo sapiens projects, skip_instrument mode (all instruments clustered together).
+ * Uses local pyspectrafuse:local Docker image with all bug fixes.
+ */
+
+params {
+    parquet_dir     = '/srv/data/spectrafuse/multi_batch1'
+    outdir          = '/srv/data/spectrafuse/multi_output'
+    skip_instrument = true
+    mgf_verbose     = false
+    max_memory      = '8.GB'
+    max_cpus        = 4
+    max_time        = '6.h'
+}
+
+process {
+    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+}
+
+docker.runOptions = ''
+docker.registry = ''

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,16 @@ params {
     // Input options
     parquet_dir = null
 
+    // Pipeline mode: 'full' (default) or 'incremental'
+    mode = 'full'
+    // Use dat bypass for full mode (15x smaller than MGF, recommended)
+    use_dat_bypass = true
+    // Path to existing cluster DB (required for incremental mode)
+    existing_cluster_db = null
+    // Default species/instrument for dat bypass when QPX metadata grouping is not yet implemented
+    default_species = null
+    default_instrument = null
+
     // MaraCluster parameters
     maracluster_pvalue_threshold = -10.0 // Set log10(p-value) threshold for MaraCluster (default -10.0 = p-value 1e-10)
     maracluster_verbose = false // Set to true to enable verbose output from MaraCluster
@@ -21,6 +31,7 @@ params {
 
     // MGF generation parameters
     mgf_verbose = true // Set to true to enable verbose output from the MGF generation step
+    skip_instrument = false // Set to true to cluster all instruments together (no instrument partitioning)
 
     // MSP format generation parameters (consensus spectrum parameters)
     strategytype = 'best' // Strategy type for consensus spectrum generation

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,9 +29,11 @@ params {
     maracluster_precursor_tolerance = 20.0 // Set the precursor tolerance for MaraCluster
     cluster_threshold = 30 // Set the p-value threshold for MaRaCluster output file naming (e.g., *_p30.tsv)
 
-    // MGF generation parameters
-    mgf_verbose = true // Set to true to enable verbose output from the MGF generation step
+    // Partitioning parameters
     skip_instrument = false // Set to true to cluster all instruments together (no instrument partitioning)
+
+    // Legacy MGF parameters (only used when use_dat_bypass = false or in incremental mode)
+    mgf_verbose = true // Set to true to enable verbose output from the MGF generation step
 
     // MSP format generation parameters (consensus spectrum parameters)
     strategytype = 'best' // Strategy type for consensus spectrum generation

--- a/phase0_split.config
+++ b/phase0_split.config
@@ -1,0 +1,34 @@
+/*
+ * Phase 0 (revised): Same-enzyme incremental quality test
+ *
+ * Step 1 — Baseline: cluster 700K subset of PXD000865-1M
+ * Step 2 — Incremental: add remaining 300K via Docker incremental workflow
+ * Step 3 — Compare: incremental result vs full 1M baseline
+ */
+
+params {
+    parquet_dir = '/srv/data/spectrafuse/test_input/phase0_split/baseline_nf'
+    outdir      = '/srv/data/spectrafuse/test_output/phase0_700k'
+    max_memory  = '8.GB'
+    max_cpus    = 4
+    max_time    = '6.h'
+    mgf_verbose = false
+
+    // MaRaCluster settings (same as full 1M baseline)
+    cluster_threshold     = 30
+    maracluster_pvalue_threshold = -10.0
+
+    strategytype = 'best'
+}
+
+process {
+    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+}
+
+docker.runOptions = ''
+docker.registry = ''

--- a/pxd004452.config
+++ b/pxd004452.config
@@ -1,0 +1,35 @@
+/*
+ * Large-scale test: PXD004452 (5.5M PSMs, Homo sapiens, Q Exactive, 620 runs)
+ *
+ * Run:
+ *   cd /srv/data/spectrafuse/repo-clone
+ *   nextflow run main.nf -c pxd004452.config -profile docker --outdir /srv/data/spectrafuse/test_output/nf_pxd004452
+ */
+
+params {
+    parquet_dir = '/srv/data/spectrafuse/test_input/pxd004452'
+    outdir      = '/srv/data/spectrafuse/test_output/nf_pxd004452'
+    max_memory  = '16.GB'
+    max_cpus    = 4
+    max_time    = '12.h'
+    mgf_verbose = false
+
+    // MaRaCluster settings
+    cluster_threshold     = 30
+    maracluster_pvalue_threshold = -10.0
+
+    // Consensus strategy
+    strategytype = 'best'
+}
+
+process {
+    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+}
+
+docker.runOptions = ''
+docker.registry = ''

--- a/workflows/spectrafuse.nf
+++ b/workflows/spectrafuse.nf
@@ -2,29 +2,138 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     SPECTRAFUSE WORKFLOW
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Main workflow for incremental spectral clustering using MaRaCluster
+    Spectral clustering using MaRaCluster.
+
+    Three modes (params.mode + params.use_dat_bypass):
+    - Full + dat bypass (default): Parquet → .dat → MaRaCluster → Cluster DB
+    - Full + legacy MGF: Parquet → MGF → MaRaCluster → MSP + Cluster Parquet
+    - Incremental: Extract reps → cluster with new data → merge back
+
+    All modes partition by species/instrument/charge.
 ----------------------------------------------------------------------------------------
 */
 
-include { GENERATE_MGF_FILES } from '../modules/local/quantmsio2mgf/generate_mgf_files/main'
-include { RUN_MARACLUSTER as RUN_MARACLUSTER_PROJECT } from '../modules/local/maracluster/run_maracluster/main'
-include { RUN_MARACLUSTER as RUN_MARACLUSTER_GLOBAL } from '../modules/local/maracluster/run_maracluster/main'
-include { GENERATE_MSP_FORMAT as GENERATE_MSP_FORMAT_PROJECT } from '../modules/local/pyspectrafuse/generate_msp_format/main'
-include { GENERATE_MSP_FORMAT as GENERATE_MSP_FORMAT_GLOBAL } from '../modules/local/pyspectrafuse/generate_msp_format/main'
-include { COMBINE_PROJECT_MSP } from '../modules/local/pyspectrafuse/combine_project_msp/main'
+// ── Full mode: dat bypass ──
+include { PARQUET_TO_DAT }       from '../modules/local/pyspectrafuse/parquet_to_dat/main'
+include { RUN_MARACLUSTER_DAT }  from '../modules/local/maracluster/run_maracluster_dat/main'
+include { BUILD_CLUSTER_DB }     from '../modules/local/pyspectrafuse/build_cluster_db/main'
 
-workflow SPECTRAFUSE {
+// ── Full mode: legacy MGF (also used for incremental new data) ──
+include { GENERATE_MGF_FILES }       from '../modules/local/quantmsio2mgf/generate_mgf_files/main'
+include { RUN_MARACLUSTER }          from '../modules/local/maracluster/run_maracluster/main'
+include { GENERATE_MSP_FORMAT }      from '../modules/local/pyspectrafuse/generate_msp_format/main'
+include { GENERATE_CLUSTER_PARQUET } from '../modules/local/pyspectrafuse/generate_cluster_parquet/main'
+
+// ── Incremental mode ──
+include { EXTRACT_REPRESENTATIVES }  from '../modules/local/pyspectrafuse/extract_representatives/main'
+include { MERGE_INCREMENTAL }        from '../modules/local/pyspectrafuse/merge_incremental/main'
+
+
+workflow SPECTRAFUSE_DAT {
+    /*
+     * FULL MODE — DAT BYPASS (recommended)
+     * Parquet → .dat (15x smaller) → MaRaCluster -D → Cluster DB
+     */
     take:
-    ch_projects  // channel: [ path(project_dir) ]
-    ch_parquet_dir  // channel: [ path(parquet_dir) ] - base directory for all projects
+    ch_projects
+    ch_parquet_dir
 
     main:
-
     ch_versions = channel.empty()
 
-    //
-    // MODULE: Generate MGF files from parquet files
-    //
+    // Step 1: Convert each project to .dat
+    ch_projects
+        .map { project_dir ->
+            [ [ id: project_dir.baseName, file_idx: 0 ], project_dir ]
+        }
+        .set { ch_projects_for_dat }
+
+    PARQUET_TO_DAT(ch_projects_for_dat)
+    ch_versions = ch_versions.mix(PARQUET_TO_DAT.out.versions)
+
+    // Step 2: Group .dat files by charge
+    PARQUET_TO_DAT.out.dat_files
+        .transpose()
+        .map { meta, dat_file ->
+            def charge_match = (dat_file.name =~ /_charge(\d+)\.dat$/)
+            if (!charge_match) return null
+            def charge = "charge${charge_match[0][1]}"
+            return [charge, meta.id, dat_file]
+        }
+        .filter { it != null }
+        .groupTuple(by: 0)
+        .map { charge, _ids, dat_files ->
+            def meta = [
+                id: "partition__${charge}",
+                species: params.default_species ?: 'Unknown',
+                instrument: params.default_instrument ?: 'Unknown',
+                charge: charge
+            ]
+            return [meta, dat_files]
+        }
+        .set { ch_grouped_dat }
+
+    PARQUET_TO_DAT.out.scan_titles
+        .transpose()
+        .map { meta, titles_file ->
+            def charge_match = (titles_file.name =~ /_charge(\d+)\.scan_titles\.txt$/)
+            if (!charge_match) return null
+            def charge = "charge${charge_match[0][1]}"
+            return [charge, titles_file]
+        }
+        .filter { it != null }
+        .groupTuple()
+        .set { ch_grouped_titles }
+
+    // Step 3: MaRaCluster with -D
+    ch_grouped_dat
+        .map { meta, dat_files -> [meta.charge, meta, dat_files] }
+        .join(ch_grouped_titles)
+        .map { _charge, meta, dat_files, titles -> [meta, dat_files, titles] }
+        .set { ch_mara_input }
+
+    RUN_MARACLUSTER_DAT(ch_mara_input)
+    ch_versions = ch_versions.mix(RUN_MARACLUSTER_DAT.out.versions)
+
+    // Step 4: Build cluster DB
+    RUN_MARACLUSTER_DAT.out.maracluster_results
+        .map { meta, tsv -> [meta.charge, meta, tsv] }
+        .join(
+            RUN_MARACLUSTER_DAT.out.scan_titles_out
+                .map { meta, titles -> [meta.charge, titles] }
+        )
+        .map { _charge, meta, tsv, titles ->
+            [meta, tsv, titles]
+        }
+        .set { ch_db_input }
+
+    // Collect all project dirs as a list for BUILD_CLUSTER_DB
+    ch_project_dirs = ch_projects.collect()
+
+    BUILD_CLUSTER_DB(
+        ch_db_input.combine(ch_project_dirs.map { dirs -> [dirs] })
+    )
+    ch_versions = ch_versions.mix(BUILD_CLUSTER_DB.out.versions)
+
+    emit:
+    maracluster_results = RUN_MARACLUSTER_DAT.out.maracluster_results
+    cluster_parquet     = BUILD_CLUSTER_DB.out.cluster_metadata
+    versions            = ch_versions
+}
+
+
+workflow SPECTRAFUSE_MGF {
+    /*
+     * FULL MODE — LEGACY MGF
+     * Parquet → MGF → MaRaCluster → MSP + Cluster Parquet
+     */
+    take:
+    ch_projects
+    ch_parquet_dir
+
+    main:
+    ch_versions = channel.empty()
+
     ch_projects
         .map { project_dir -> [ [ id: project_dir.baseName ], project_dir ] }
         .set { ch_projects_with_meta }
@@ -32,217 +141,163 @@ workflow SPECTRAFUSE {
     GENERATE_MGF_FILES(ch_projects_with_meta)
     ch_versions = ch_versions.mix(GENERATE_MGF_FILES.out.versions)
 
-    //
-    // PROJECT-LEVEL CLUSTERING: Group MGF files within each project by species, instrument, and charge
-    //
-    // Extract project info from MGF file paths and group by project first
     GENERATE_MGF_FILES.out.mgf_files
         .flatten()
         .map { file ->
             def pathParts = file.toString().split('/')
-            def mgf_output_index = pathParts.findIndexOf { pathPart -> pathPart == 'mgf_output' }
-            
-            if (mgf_output_index == -1) {
-                return null
-            }
-            
-            // Extract project info from path (project directory is before mgf_output)
-            def project_dir_index = mgf_output_index - 1
-            def project_dir = project_dir_index >= 0 ? pathParts[0..<mgf_output_index].join('/') : null
-            def project_id = project_dir ? new File(project_dir).getName() : null
-            
-            def species = pathParts[mgf_output_index + 1]
-            def instrument = pathParts[mgf_output_index + 2]
-            def charge = pathParts[mgf_output_index + 3]
-            def key = "${species}/${instrument}/${charge}"
-            
-            def id = "${project_id}__${species}__${instrument}__${charge}"
-                .replaceAll(/[\\/]/, '_')
-                .replaceAll(/\s+/, '_')
-            
-            def meta = [
-                id: id,
-                project_id: project_id,
-                species: species,
-                instrument: instrument,
-                charge: charge,
-                project_dir: project_dir
-            ]
-            
-            // Return [project_id, key, meta, file] for grouping
-            return [project_id, key, meta, file]
-        }
-        .filter { item -> item != null }
-        .groupTuple(by: [0, 1])  // Group by project_id and key
-        .map { project_id, key, meta_list, files_list ->
-            // All items in meta_list should have same species/instrument/charge
-            def meta = meta_list[0]
-            def files = files_list.flatten()
-            return [meta, files]
-        }
-        .set { ch_project_mgf_files_with_meta }
+            def idx = pathParts.findIndexOf { it == 'mgf_output' }
+            if (idx == -1) return null
 
-    //
-    // PROJECT-LEVEL: Run MaRaCluster on grouped MGF files within each project
-    //
-    RUN_MARACLUSTER_PROJECT(ch_project_mgf_files_with_meta)
-    ch_versions = ch_versions.mix(RUN_MARACLUSTER_PROJECT.out.versions)
-    
-    // Pass through project metadata
-    RUN_MARACLUSTER_PROJECT.out.maracluster_results
-        .set { ch_project_maracluster_results }
-
-    //
-    // PROJECT-LEVEL: Generate MSP format files per project (per species/instrument/charge)
-    //
-    GENERATE_MSP_FORMAT_PROJECT(
-        ch_parquet_dir,
-        ch_project_maracluster_results
-    )
-    ch_versions = ch_versions.mix(GENERATE_MSP_FORMAT_PROJECT.out.versions)
-    
-    // Group MSP files by project for combination
-    // Extract project info directly from MSP file paths and join with original project directories
-    GENERATE_MSP_FORMAT_PROJECT.out.msp_files
-        .flatten()
-        .filter { msp_file ->
-            // Only keep actual .msp files, not directories
-            msp_file.toString().endsWith('.msp')
-        }
-        .map { msp_file ->
-            // Extract project_id from MSP file path
-            // Path structure: .../work/.../test_data/msp/species/instrument/charge/file.msp
-            // Or: .../work/.../PXD*/msp/species/instrument/charge/file.msp
-            def pathParts = msp_file.toString().split('/')
-            def project_id = null
-            
-            // Find project directory (contains PXD or is in test_data structure)
-            for (int i = 0; i < pathParts.length; i++) {
-                if (pathParts[i].contains('PXD') || pathParts[i].matches(/^PXD\\d+/)) {
-                    project_id = pathParts[i]
-                    break
-                }
-            }
-            // Fallback: if in test_data structure, project might be in parquet_dir
-            if (!project_id) {
-                def test_data_index = pathParts.findIndexOf { it == 'test_data' }
-                if (test_data_index >= 0 && test_data_index + 1 < pathParts.length) {
-                    // Try to find project name after test_data
-                    project_id = pathParts[test_data_index + 1]
-                }
-            }
-            if (!project_id) {
-                return null
-            }
-            return [project_id, msp_file]
-        }
-        .filter { it != null }
-        .groupTuple(by: 0)  // Group by project_id
-        .map { project_id, msp_files_list ->
-            // Flatten and filter MSP files
-            def all_msp_files = msp_files_list.flatten().findAll { file ->
-                file.toString().endsWith('.msp')
-            }
-            if (all_msp_files.isEmpty()) {
-                return null
-            }
-            return [project_id, all_msp_files]
-        }
-        .filter { it != null }
-        .join(ch_projects_with_meta.map { meta, project_dir -> [meta.id, project_dir] }, by: 0)  // Join to get original project_dir
-        .map { project_id, msp_files_list, project_dir ->
-            def project_meta_combined = [
-                id: project_id,
-                project_dir: project_dir.toString()
-            ]
-            return [project_meta_combined, project_dir, msp_files_list]
-        }
-        .set { ch_project_msp_files_for_combine }
-    
-    // Split into two channels - Nextflow will automatically synchronize them since they come from the same source
-    // The msp_files list will be passed as a collection to the path() input
-    ch_project_info_for_combine = ch_project_msp_files_for_combine.map { project_meta, project_dir, msp_files -> [project_meta, project_dir] }
-    ch_project_msp_files_list = ch_project_msp_files_for_combine.map { project_meta, project_dir, msp_files -> msp_files }
-    
-    COMBINE_PROJECT_MSP(
-        ch_project_info_for_combine,
-        ch_project_msp_files_list
-    )
-    ch_versions = ch_versions.mix(COMBINE_PROJECT_MSP.out.versions)
-
-    //
-    // GLOBAL CLUSTERING: Process MGF files: Group by species, instrument, and charge ACROSS projects
-    //
-    GENERATE_MGF_FILES.out.mgf_files
-        .flatten()
-        .map { file ->
-            def pathParts = file.toString().split('/')
-            def mgf_output_index = pathParts.findIndexOf { pathPart -> pathPart == 'mgf_output' }
-
-            if (mgf_output_index == -1) {
-                log.warn "Warning: Could not find 'mgf_output' in path: ${file}"
-                return null
-            }
-
-            // Create keys based on species, instrument, and charge
-            // Use slash format to match main branch behavior
-            def species = pathParts[mgf_output_index + 1]
-            def instrument = pathParts[mgf_output_index + 2]
-            def charge = pathParts[mgf_output_index + 3]
-
-            def key = "${species}/${instrument}/${charge}"
-
-            // Create a meta map (nf-core style) including a stable id for tags/logs
-            // NOTE: Keep id filesystem-friendly (no slashes, minimal whitespace)
-            def id = "${species}__${instrument}__${charge}"
-                .replaceAll(/[\\/]/, '_')
-                .replaceAll(/\s+/, '_')
-
-            def meta = [
-                id: id,
-                species: species,
-                instrument: instrument,
-                charge: charge
-            ]
-
+            def species = pathParts[idx + 1]
+            def instrument = params.skip_instrument ? 'all_instruments' : pathParts[idx + 2]
+            def charge = pathParts[idx + 3]
+            def key = params.skip_instrument
+                ? "${species}/${charge}" : "${species}/${instrument}/${charge}"
+            def id = key.replaceAll(/[\\/]/, '__').replaceAll(/\s+/, '_')
+            def meta = [ id: id, species: species, instrument: instrument, charge: charge ]
             return [key, meta, file]
         }
-        .filter { item ->
-            item != null
-        }
+        .filter { it != null }
         .groupTuple(by: 0)
-        .map { _key, meta_list, files ->
-            // All items in meta_list should be identical for the same key
-            def meta = meta_list[0]
-            return [meta, files]
-        }
-        .set { ch_grouped_mgf_files_with_meta }
+        .map { _key, meta_list, files -> [meta_list[0], files] }
+        .set { ch_grouped_mgf }
 
-    //
-    // GLOBAL: Run MaRaCluster on grouped MGF files across all projects
-    // Pass metadata through as tuple to match main branch behavior
-    //
-    RUN_MARACLUSTER_GLOBAL(ch_grouped_mgf_files_with_meta)
-    ch_versions = ch_versions.mix(RUN_MARACLUSTER_GLOBAL.out.versions)
-    
-    // Get global clustering results
-    RUN_MARACLUSTER_GLOBAL.out.maracluster_results
-        .set { ch_global_maracluster_results }
+    RUN_MARACLUSTER(ch_grouped_mgf)
+    ch_versions = ch_versions.mix(RUN_MARACLUSTER.out.versions)
 
-    //
-    // GLOBAL: Generate MSP format files from global clustering results
-    //
-    // Pass parquet_dir directly - Nextflow automatically broadcasts single-value channels
-    // to each item in RUN_MARACLUSTER_GLOBAL.out.maracluster_results, ensuring parquet_dir is available for all MSP tasks
-    GENERATE_MSP_FORMAT_GLOBAL(
-        ch_parquet_dir,
-        ch_global_maracluster_results
-    )
-    ch_versions = ch_versions.mix(GENERATE_MSP_FORMAT_GLOBAL.out.versions)
+    GENERATE_MSP_FORMAT(ch_parquet_dir, RUN_MARACLUSTER.out.maracluster_results)
+    ch_versions = ch_versions.mix(GENERATE_MSP_FORMAT.out.versions)
+
+    GENERATE_CLUSTER_PARQUET(ch_parquet_dir, RUN_MARACLUSTER.out.maracluster_results)
+    ch_versions = ch_versions.mix(GENERATE_CLUSTER_PARQUET.out.versions)
 
     emit:
-    project_msp_files    = COMBINE_PROJECT_MSP.out.project_msp_file
-    maracluster_results  = ch_global_maracluster_results
-    msp_files            = GENERATE_MSP_FORMAT_GLOBAL.out.msp_files
-    versions             = ch_versions
+    maracluster_results = RUN_MARACLUSTER.out.maracluster_results
+    cluster_parquet     = GENERATE_CLUSTER_PARQUET.out.cluster_parquet_files
+    versions            = ch_versions
+}
+
+
+workflow SPECTRAFUSE_INCREMENTAL {
+    /*
+     * INCREMENTAL MODE
+     * Extract reps from existing DB → cluster with new data → merge
+     */
+    take:
+    ch_projects
+    ch_parquet_dir
+
+    main:
+    ch_versions = channel.empty()
+
+    // Load existing cluster DB
+    ch_existing_db = channel.fromPath("${params.existing_cluster_db}/**/cluster_metadata.parquet")
+        .map { meta_file ->
+            def membership = meta_file.parent.resolve('psm_cluster_membership.parquet')
+            def charge = meta_file.parent.parent.name
+            def instrument = meta_file.parent.parent.parent.name
+            def species = meta_file.parent.parent.parent.parent.name
+            def id = "${species}__${instrument}__${charge}"
+                .replaceAll(/[\\/]/, '_').replaceAll(/\s+/, '_')
+            def meta = [ id: id, species: species, instrument: instrument, charge: charge ]
+            return [meta, meta_file, membership]
+        }
+
+    // Step 1: Extract representatives
+    EXTRACT_REPRESENTATIVES(
+        ch_existing_db.map { meta, meta_file, _mem -> [meta, meta_file] }
+    )
+    ch_versions = ch_versions.mix(EXTRACT_REPRESENTATIVES.out.versions)
+
+    // Step 2: Convert new data to MGF
+    ch_projects
+        .map { project_dir -> [ [ id: project_dir.baseName ], project_dir ] }
+        .set { ch_projects_with_meta }
+
+    GENERATE_MGF_FILES(ch_projects_with_meta)
+    ch_versions = ch_versions.mix(GENERATE_MGF_FILES.out.versions)
+
+    // Step 3: Group new MGFs by partition key
+    GENERATE_MGF_FILES.out.mgf_files
+        .flatten()
+        .map { file ->
+            def pathParts = file.toString().split('/')
+            def idx = pathParts.findIndexOf { it == 'mgf_output' }
+            if (idx == -1) return null
+            def species = pathParts[idx + 1]
+            def instrument = params.skip_instrument ? 'all_instruments' : pathParts[idx + 2]
+            def charge = pathParts[idx + 3]
+            def key = "${species}__${instrument}__${charge}"
+                .replaceAll(/[\\/]/, '_').replaceAll(/\s+/, '_')
+            return [key, file]
+        }
+        .filter { it != null }
+        .groupTuple()
+        .set { ch_new_mgf }
+
+    // Combine reps + new MGFs
+    EXTRACT_REPRESENTATIVES.out.representative_mgf
+        .map { meta, mgf -> [meta.id, meta, mgf] }
+        .join(ch_new_mgf)
+        .map { _id, meta, rep_mgf, new_mgfs ->
+            [meta, [rep_mgf, new_mgfs].flatten()]
+        }
+        .set { ch_combined_mgf }
+
+    RUN_MARACLUSTER(ch_combined_mgf)
+    ch_versions = ch_versions.mix(RUN_MARACLUSTER.out.versions)
+
+    // Step 4: Merge
+    RUN_MARACLUSTER.out.maracluster_results
+        .map { meta, tsv -> [meta.id, meta, tsv] }
+        .join(
+            EXTRACT_REPRESENTATIVES.out.representative_mgf.map { meta, mgf -> [meta.id, mgf] }
+        )
+        .join(
+            ch_existing_db.map { meta, mf, mem -> [meta.id, mf, mem] }
+        )
+        .map { _id, meta, tsv, rep_mgf, mf, mem -> [meta, tsv, rep_mgf, mf, mem] }
+        .set { ch_merge_input }
+
+    MERGE_INCREMENTAL(ch_parquet_dir, ch_merge_input)
+    ch_versions = ch_versions.mix(MERGE_INCREMENTAL.out.versions)
+
+    emit:
+    maracluster_results = RUN_MARACLUSTER.out.maracluster_results
+    cluster_parquet     = MERGE_INCREMENTAL.out.cluster_parquet_files
+    versions            = ch_versions
+}
+
+
+workflow SPECTRAFUSE {
+    /*
+     * Router workflow — dispatches to the correct sub-workflow based on params.
+     */
+    take:
+    ch_projects
+    ch_parquet_dir
+
+    main:
+
+    if (params.mode == 'incremental') {
+        SPECTRAFUSE_INCREMENTAL(ch_projects, ch_parquet_dir)
+        ch_results = SPECTRAFUSE_INCREMENTAL.out.maracluster_results
+        ch_parquet = SPECTRAFUSE_INCREMENTAL.out.cluster_parquet
+        ch_versions = SPECTRAFUSE_INCREMENTAL.out.versions
+    } else if (params.use_dat_bypass) {
+        SPECTRAFUSE_DAT(ch_projects, ch_parquet_dir)
+        ch_results = SPECTRAFUSE_DAT.out.maracluster_results
+        ch_parquet = SPECTRAFUSE_DAT.out.cluster_parquet
+        ch_versions = SPECTRAFUSE_DAT.out.versions
+    } else {
+        SPECTRAFUSE_MGF(ch_projects, ch_parquet_dir)
+        ch_results = SPECTRAFUSE_MGF.out.maracluster_results
+        ch_parquet = SPECTRAFUSE_MGF.out.cluster_parquet
+        ch_versions = SPECTRAFUSE_MGF.out.versions
+    }
+
+    emit:
+    maracluster_results = ch_results
+    cluster_parquet     = ch_parquet
+    versions            = ch_versions
 }


### PR DESCRIPTION
## Summary
- Redesign Nextflow workflow into 3 modes: full+dat-bypass (default), full+legacy-MGF, and incremental clustering
- Add 7 new process modules: `parquet_to_dat`, `run_maracluster_dat`, `build_cluster_db`, `generate_cluster_parquet`, `extract_representatives`, `merge_incremental`, `parquet_to_dat`
- Add config profiles for e2e testing, multi-project runs, phase0 split benchmark, and PXD004452

## Details
The dat bypass path writes MaRaCluster's internal `.dat` binary format directly from parquet (15x smaller than MGF), and MaRaCluster reads them with `-D` flag. The incremental mode adds new data to existing cluster DBs without re-clustering everything.

## Test plan
- [ ] Run e2e test on PXD014877 with `nextflow run main.nf -c e2e.config`
- [ ] Verify dat bypass produces equivalent clusters to legacy MGF path
- [ ] Test incremental mode with existing cluster DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)