### PR TITLE
Remove MGF/bypass terminology — parquet-to-dat is the standard path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ quantms has reanalyzed an extensive number of datasets with almost 1 billion MS/
 
 ![SpectrafUSE Workflow](docs/images/spectrafuse_workflow.svg)
 
-The pipeline converts QPX parquet files directly into MaRaCluster's internal `.dat` binary format, bypassing MGF text files entirely. This **dat bypass** approach is 15x smaller than MGF (100 bytes/spectrum vs ~1.5 KB), making it feasible to cluster datasets with millions of PSMs on standard hardware.
+The pipeline converts QPX parquet files directly into MaRaCluster's internal `.dat` binary format (~100 bytes/spectrum), making it feasible to cluster datasets with millions of PSMs on standard hardware.
 
 The pipeline supports three modes:
 
@@ -30,7 +30,7 @@ Adds new data to an existing cluster DB without re-clustering everything.
 
 1. **Extract Representatives** (`EXTRACT_REPRESENTATIVES`): Reads cluster metadata and writes one consensus spectrum per existing cluster.
 
-2. **Convert New Data** (`GENERATE_MGF_FILES`): Converts new project PSMs to charge-specific MGFs.
+2. **Convert New Data**: Converts new project PSMs to charge-specific spectrum files.
 
 3. **MaRaCluster** (`RUN_MARACLUSTER`): Clusters representatives + new data together. Representatives that land in the same new cluster as new spectra link those spectra to the existing cluster.
 
@@ -38,7 +38,7 @@ Adds new data to an existing cluster DB without re-clustering everything.
 
 ### Key Features
 
-- **No MGF intermediate files**: The dat bypass eliminates MGF text inflation (12.8M PSMs = 1.3 GB `.dat` vs ~85 GB MGF)
+- **Compact binary format**: Parquet-to-dat conversion produces ~1.3 GB for 12.8M PSMs
 - **Incremental clustering**: Add new datasets without re-clustering existing data
 - **Parallel processing**: Projects and charge partitions are processed in parallel
 - **Partitioned by metadata**: Clustering is performed separately for each species/instrument/charge combination
@@ -93,7 +93,7 @@ cd spectrafuse
 
 ## Usage
 
-### Full Mode (dat bypass, default)
+### Full Mode (default)
 
 ```bash
 nextflow run main.nf \

--- a/conf/tests/test.config
+++ b/conf/tests/test.config
@@ -25,15 +25,12 @@ params {
     outdir = "./results_test"
 
     // Input data
-    // Test data is downloaded from FTP server in CI workflow
     // The parquet_dir should point to a directory containing project subdirectories
-    // Each project directory should contain parquet files and SDRF files
+    // Each project directory should contain QPX parquet files (.psm.parquet, .run.parquet, .sample.parquet)
     parquet_dir = "${projectDir}/test_data"
 
     // Use minimal parameters for faster CI testing
     cluster_threshold = 30
     maracluster_pvalue_threshold = -10.0
     maracluster_verbose = false
-    mgf_verbose = false
 }
-

--- a/docs/images/spectrafuse_workflow.svg
+++ b/docs/images/spectrafuse_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1050" width="900" height="1050">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 950" width="750" height="950">
   <defs>
     <style>
       .station-label {
@@ -56,15 +56,15 @@
   </defs>
 
   <!-- Background -->
-  <rect width="900" height="1050" fill="#ffffff"/>
+  <rect width="750" height="950" fill="#ffffff"/>
 
   <!-- Title -->
-  <text x="450" y="35" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="bold" fill="#333">SpectrafUSE Pipeline Workflow</text>
-  <text x="450" y="52" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="11" fill="#888">Spectral clustering pipeline for PRIDE/MSnet proteomics reanalysis</text>
+  <text x="375" y="35" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="bold" fill="#333">SpectrafUSE Pipeline Workflow</text>
+  <text x="375" y="52" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="11" fill="#888">Spectral clustering pipeline for PRIDE/MSnet proteomics reanalysis</text>
 
   <!-- ==================== LEGEND (top right) ==================== -->
-  <g transform="translate(680, 70)">
-    <rect x="-10" y="-15" width="215" height="175" rx="6" fill="#f9f9f9" stroke="#e0e0e0" stroke-width="1"/>
+  <g transform="translate(550, 70)">
+    <rect x="-10" y="-15" width="195" height="150" rx="6" fill="#f9f9f9" stroke="#e0e0e0" stroke-width="1"/>
     <text x="0" y="0" class="legend-title">Legend</text>
 
     <!-- Filled circle = Process -->
@@ -85,49 +85,40 @@
 
     <!-- Mode colors -->
     <rect x="2" y="105" width="14" height="10" rx="2" fill="#00897B"/>
-    <text x="24" y="114" class="legend-text">Dat Bypass (recommended)</text>
+    <text x="24" y="114" class="legend-text">Full Mode</text>
 
-    <rect x="2" y="122" width="14" height="10" rx="2" fill="#43A047"/>
-    <text x="24" y="131" class="legend-text">Legacy MGF</text>
-
-    <rect x="2" y="139" width="14" height="10" rx="2" fill="#8E24AA"/>
-    <text x="24" y="148" class="legend-text">Incremental</text>
+    <rect x="2" y="122" width="14" height="10" rx="2" fill="#8E24AA"/>
+    <text x="24" y="131" class="legend-text">Incremental Mode</text>
   </g>
 
   <!-- ==================== SHARED INPUT (Blue) ==================== -->
   <!-- Input station -->
-  <circle cx="450" cy="100" r="9" fill="#1565C0"/>
-  <text x="450" y="96" text-anchor="end" dx="-18" class="station-label" fill="#1565C0">QPX Parquet Files</text>
-  <text x="450" y="112" text-anchor="end" dx="-18" class="station-sublabel">.psm.parquet + .run.parquet + .sample.parquet</text>
+  <circle cx="375" cy="100" r="9" fill="#1565C0"/>
+  <text x="375" y="96" text-anchor="end" dx="-18" class="station-label" fill="#1565C0">QPX Parquet Files</text>
+  <text x="375" y="112" text-anchor="end" dx="-18" class="station-sublabel">.psm.parquet + .run.parquet + .sample.parquet</text>
 
   <!-- Line from input to router -->
-  <line x1="450" y1="109" x2="450" y2="155" stroke="#1565C0" stroke-width="5"/>
+  <line x1="375" y1="109" x2="375" y2="155" stroke="#1565C0" stroke-width="5"/>
 
   <!-- Mode Router Diamond -->
-  <polygon points="450,155 480,185 450,215 420,185" fill="none" stroke="#1565C0" stroke-width="2.5"/>
-  <text x="450" y="183" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="9" font-weight="bold" fill="#1565C0">--mode</text>
-  <text x="450" y="193" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="8" fill="#1565C0">--use_dat_bypass</text>
+  <polygon points="375,155 405,185 375,215 345,185" fill="none" stroke="#1565C0" stroke-width="2.5"/>
+  <text x="375" y="188" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="9" font-weight="bold" fill="#1565C0">--mode</text>
 
   <!-- ==================== COLUMN HEADERS ==================== -->
-  <!-- Dat Bypass header -->
-  <text x="200" y="260" text-anchor="middle" class="mode-label" fill="#00897B">Dat Bypass Mode</text>
-  <text x="200" y="274" text-anchor="middle" class="mode-sublabel" fill="#00897B">(default, recommended)</text>
-
-  <!-- Legacy MGF header -->
-  <text x="450" y="260" text-anchor="middle" class="mode-label" fill="#43A047">Legacy MGF Mode</text>
+  <!-- Full Mode header -->
+  <text x="200" y="260" text-anchor="middle" class="mode-label" fill="#00897B">Full Mode</text>
+  <text x="200" y="274" text-anchor="middle" class="mode-sublabel" fill="#00897B">(default)</text>
 
   <!-- Incremental header -->
-  <text x="700" y="260" text-anchor="middle" class="mode-label" fill="#8E24AA">Incremental Mode</text>
+  <text x="550" y="260" text-anchor="middle" class="mode-label" fill="#8E24AA">Incremental Mode</text>
 
   <!-- ==================== ROUTER TO COLUMNS ==================== -->
-  <!-- Router to Dat Bypass -->
-  <path d="M 435,200 Q 350,235 200,285" fill="none" stroke="#00897B" stroke-width="5"/>
-  <!-- Router to Legacy MGF -->
-  <line x1="450" y1="215" x2="450" y2="285" stroke="#43A047" stroke-width="5"/>
+  <!-- Router to Full Mode -->
+  <path d="M 360,200 Q 300,235 200,285" fill="none" stroke="#00897B" stroke-width="5"/>
   <!-- Router to Incremental -->
-  <path d="M 465,200 Q 550,235 700,285" fill="none" stroke="#8E24AA" stroke-width="5"/>
+  <path d="M 390,200 Q 450,235 550,285" fill="none" stroke="#8E24AA" stroke-width="5"/>
 
-  <!-- ==================== DAT BYPASS COLUMN (Teal) ==================== -->
+  <!-- ==================== FULL MODE COLUMN (Teal) ==================== -->
   <!-- Station 1: PARQUET_TO_DAT -->
   <line x1="200" y1="295" x2="200" y2="390" stroke="#00897B" stroke-width="5"/>
   <circle cx="200" cy="305" r="9" fill="#00897B"/>
@@ -136,7 +127,7 @@
     <text x="142" y="306" text-anchor="middle">PARQUET_TO_DAT</text>
   </g>
   <text x="220" y="302" class="station-label">Parquet to .dat</text>
-  <text x="220" y="316" class="station-sublabel">15x smaller than MGF</text>
+  <text x="220" y="316" class="station-sublabel">~100 bytes/spectrum binary format</text>
 
   <!-- Station 2: Group by charge -->
   <circle cx="200" cy="400" r="6" fill="#00897B"/>
@@ -151,7 +142,7 @@
     <text x="134" y="491" text-anchor="middle">RUN_MARACLUSTER_DAT</text>
   </g>
   <text x="220" y="487" class="station-label">MaRaCluster -D</text>
-  <text x="220" y="501" class="station-sublabel">reads .dat directly</text>
+  <text x="220" y="501" class="station-sublabel">reads .dat files directly</text>
 
   <line x1="200" y1="499" x2="200" y2="580" stroke="#00897B" stroke-width="5"/>
 
@@ -164,147 +155,87 @@
   <text x="220" y="587" class="station-label">Build Cluster DB</text>
   <text x="220" y="601" class="station-sublabel">metadata + membership parquets</text>
 
-  <!-- ==================== LEGACY MGF COLUMN (Green) ==================== -->
-  <!-- Station 1: GENERATE_MGF_FILES -->
-  <line x1="450" y1="295" x2="450" y2="390" stroke="#43A047" stroke-width="5"/>
-  <circle cx="450" cy="305" r="9" fill="#43A047"/>
-  <g class="tool-badge">
-    <rect x="348" y="295" width="90" height="16" rx="3" fill="#43A047"/>
-    <text x="393" y="306" text-anchor="middle">GENERATE_MGF_FILES</text>
-  </g>
-  <text x="470" y="302" class="station-label">Parquet to MGF</text>
-  <text x="470" y="316" class="station-sublabel">grouped by species/instrument/charge</text>
-
-  <!-- Station 2: RUN_MARACLUSTER -->
-  <circle cx="450" cy="400" r="9" fill="#43A047"/>
-  <g class="tool-badge">
-    <rect x="355" y="390" width="80" height="16" rx="3" fill="#43A047"/>
-    <text x="395" y="401" text-anchor="middle">RUN_MARACLUSTER</text>
-  </g>
-  <text x="470" y="397" class="station-label">MaRaCluster</text>
-  <text x="470" y="411" class="station-sublabel">spectral clustering</text>
-
-  <!-- Branch: two parallel outputs from RUN_MARACLUSTER -->
-  <!-- Left branch to MSP -->
-  <path d="M 450,409 L 450,440 L 390,470" stroke="#43A047" stroke-width="5" fill="none"/>
-  <!-- Right branch to Cluster Parquet -->
-  <path d="M 450,409 L 450,440 L 510,470" stroke="#43A047" stroke-width="5" fill="none"/>
-
-  <!-- Station 3a: GENERATE_MSP_FORMAT -->
-  <line x1="390" y1="470" x2="390" y2="490" stroke="#43A047" stroke-width="5"/>
-  <circle cx="390" cy="490" r="9" fill="#43A047"/>
-  <g class="tool-badge">
-    <rect x="278" y="480" width="100" height="16" rx="3" fill="#43A047"/>
-    <text x="328" y="491" text-anchor="middle">GENERATE_MSP_FORMAT</text>
-  </g>
-  <text x="310" y="510" class="station-label">Consensus MSP</text>
-  <text x="310" y="524" class="station-sublabel">best/bin consensus spectra</text>
-
-  <!-- Station 3b: GENERATE_CLUSTER_PARQUET -->
-  <line x1="510" y1="470" x2="510" y2="490" stroke="#43A047" stroke-width="5"/>
-  <circle cx="510" cy="490" r="9" fill="#43A047"/>
-  <g class="tool-badge">
-    <rect x="524" y="480" width="120" height="16" rx="3" fill="#43A047"/>
-    <text x="584" y="491" text-anchor="middle">GENERATE_CLUSTER_PARQUET</text>
-  </g>
-  <text x="530" y="510" class="station-label">Cluster Parquet</text>
-  <text x="530" y="524" class="station-sublabel">cluster membership DB</text>
-
-  <!-- Merge back -->
-  <path d="M 390,499 L 390,550 L 450,580" stroke="#43A047" stroke-width="5" fill="none"/>
-  <path d="M 510,499 L 510,550 L 450,580" stroke="#43A047" stroke-width="5" fill="none"/>
-
   <!-- ==================== INCREMENTAL COLUMN (Purple) ==================== -->
   <!-- Split into two parallel inputs -->
   <!-- Left rail: EXTRACT_REPRESENTATIVES -->
-  <path d="M 700,285 L 660,310" stroke="#8E24AA" stroke-width="5" fill="none"/>
-  <line x1="660" y1="310" x2="660" y2="390" stroke="#8E24AA" stroke-width="5"/>
-  <circle cx="660" cy="320" r="9" fill="#8E24AA"/>
+  <path d="M 550,285 L 510,310" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <line x1="510" y1="310" x2="510" y2="390" stroke="#8E24AA" stroke-width="5"/>
+  <circle cx="510" cy="320" r="9" fill="#8E24AA"/>
   <g class="tool-badge">
-    <rect x="540" y="310" width="108" height="16" rx="3" fill="#8E24AA"/>
-    <text x="594" y="321" text-anchor="middle">EXTRACT_REPRESENTATIVES</text>
+    <rect x="390" y="310" width="108" height="16" rx="3" fill="#8E24AA"/>
+    <text x="444" y="321" text-anchor="middle">EXTRACT_REPRESENTATIVES</text>
   </g>
-  <text x="608" y="338" class="station-label" text-anchor="end">Extract Reps</text>
-  <text x="608" y="352" class="station-sublabel" text-anchor="end">one spectrum per existing cluster</text>
+  <text x="458" y="338" class="station-label" text-anchor="end">Extract Reps</text>
+  <text x="458" y="352" class="station-sublabel" text-anchor="end">one spectrum per existing cluster</text>
 
-  <!-- Right rail: GENERATE_MGF_FILES (new data) -->
-  <path d="M 700,285 L 740,310" stroke="#8E24AA" stroke-width="5" fill="none"/>
-  <line x1="740" y1="310" x2="740" y2="390" stroke="#8E24AA" stroke-width="5"/>
-  <circle cx="740" cy="320" r="9" fill="#8E24AA"/>
+  <!-- Right rail: Convert new data -->
+  <path d="M 550,285 L 590,310" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <line x1="590" y1="310" x2="590" y2="390" stroke="#8E24AA" stroke-width="5"/>
+  <circle cx="590" cy="320" r="9" fill="#8E24AA"/>
   <g class="tool-badge">
-    <rect x="755" y="310" width="90" height="16" rx="3" fill="#8E24AA"/>
-    <text x="800" y="321" text-anchor="middle">GENERATE_MGF_FILES</text>
+    <rect x="605" y="310" width="100" height="16" rx="3" fill="#8E24AA"/>
+    <text x="655" y="321" text-anchor="middle">CONVERT_NEW_DATA</text>
   </g>
-  <text x="755" y="338" class="station-label">New Data to MGF</text>
-  <text x="755" y="352" class="station-sublabel">convert new project PSMs</text>
+  <text x="605" y="338" class="station-label">New Data</text>
+  <text x="605" y="352" class="station-sublabel">convert new project PSMs</text>
 
   <!-- Merge rails -->
-  <path d="M 660,390 L 700,420" stroke="#8E24AA" stroke-width="5" fill="none"/>
-  <path d="M 740,390 L 700,420" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <path d="M 510,390 L 550,420" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <path d="M 590,390 L 550,420" stroke="#8E24AA" stroke-width="5" fill="none"/>
 
-  <line x1="700" y1="420" x2="700" y2="490" stroke="#8E24AA" stroke-width="5"/>
+  <line x1="550" y1="420" x2="550" y2="490" stroke="#8E24AA" stroke-width="5"/>
 
   <!-- Station 3: RUN_MARACLUSTER -->
-  <circle cx="700" cy="490" r="9" fill="#8E24AA"/>
+  <circle cx="550" cy="490" r="9" fill="#8E24AA"/>
   <g class="tool-badge">
-    <rect x="605" y="480" width="80" height="16" rx="3" fill="#8E24AA"/>
-    <text x="645" y="491" text-anchor="middle">RUN_MARACLUSTER</text>
+    <rect x="455" y="480" width="80" height="16" rx="3" fill="#8E24AA"/>
+    <text x="495" y="491" text-anchor="middle">RUN_MARACLUSTER</text>
   </g>
-  <text x="720" y="487" class="station-label">MaRaCluster</text>
-  <text x="720" y="501" class="station-sublabel">reps + new data together</text>
+  <text x="570" y="487" class="station-label">MaRaCluster</text>
+  <text x="570" y="501" class="station-sublabel">reps + new data together</text>
 
-  <line x1="700" y1="499" x2="700" y2="580" stroke="#8E24AA" stroke-width="5"/>
+  <line x1="550" y1="499" x2="550" y2="580" stroke="#8E24AA" stroke-width="5"/>
 
   <!-- Station 4: MERGE_INCREMENTAL -->
-  <circle cx="700" cy="590" r="9" fill="#8E24AA"/>
+  <circle cx="550" cy="590" r="9" fill="#8E24AA"/>
   <g class="tool-badge">
-    <rect x="592" y="580" width="95" height="16" rx="3" fill="#8E24AA"/>
-    <text x="639" y="591" text-anchor="middle">MERGE_INCREMENTAL</text>
+    <rect x="442" y="580" width="95" height="16" rx="3" fill="#8E24AA"/>
+    <text x="489" y="591" text-anchor="middle">MERGE_INCREMENTAL</text>
   </g>
-  <text x="720" y="587" class="station-label">Merge Clusters</text>
-  <text x="720" y="601" class="station-sublabel">resolve IDs, update membership</text>
+  <text x="570" y="587" class="station-label">Merge Clusters</text>
+  <text x="570" y="601" class="station-sublabel">resolve IDs, update membership</text>
 
   <!-- ==================== EXISTING CLUSTER DB INPUT (Purple, dashed) ==================== -->
-  <circle cx="830" cy="260" r="8" fill="none" stroke="#8E24AA" stroke-width="2"/>
-  <text x="830" y="255" text-anchor="middle" class="station-sublabel" fill="#8E24AA">Existing</text>
-  <text x="830" y="245" text-anchor="middle" class="station-sublabel" fill="#8E24AA">Cluster DB</text>
-  <line x1="820" y1="268" x2="670" y2="312" stroke="#8E24AA" stroke-width="3" stroke-dasharray="6,3"/>
+  <circle cx="680" cy="260" r="8" fill="none" stroke="#8E24AA" stroke-width="2"/>
+  <text x="680" y="255" text-anchor="middle" class="station-sublabel" fill="#8E24AA">Existing</text>
+  <text x="680" y="245" text-anchor="middle" class="station-sublabel" fill="#8E24AA">Cluster DB</text>
+  <line x1="670" y1="268" x2="520" y2="312" stroke="#8E24AA" stroke-width="3" stroke-dasharray="6,3"/>
 
   <!-- ==================== SHARED OUTPUTS (Orange) ==================== -->
-  <text x="450" y="680" text-anchor="middle" class="section-title" fill="#999">OUTPUTS</text>
+  <text x="375" y="680" text-anchor="middle" class="section-title" fill="#999">OUTPUTS</text>
 
   <!-- Convergence lines to outputs -->
-  <!-- Dat Bypass to Cluster DB -->
+  <!-- Full Mode to Cluster DB -->
   <path d="M 200,599 L 200,720 L 310,740" stroke="#00897B" stroke-width="5" fill="none"/>
-  <!-- Legacy MGF to Cluster DB -->
-  <path d="M 450,580 L 450,700 L 390,740" stroke="#43A047" stroke-width="5" fill="none"/>
   <!-- Incremental to Cluster DB -->
-  <path d="M 700,599 L 700,720 L 440,740" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <path d="M 550,599 L 550,720 L 440,740" stroke="#8E24AA" stroke-width="5" fill="none"/>
 
   <!-- Output 1: Cluster DB -->
-  <circle cx="370" cy="750" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
-  <text x="390" y="747" class="station-label" fill="#F57C00">Cluster DB</text>
-  <text x="390" y="763" class="station-sublabel">cluster_metadata.parquet + psm_cluster_membership.parquet</text>
+  <circle cx="375" cy="750" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+  <text x="395" y="747" class="station-label" fill="#F57C00">Cluster DB</text>
+  <text x="395" y="763" class="station-sublabel">cluster_metadata.parquet + psm_cluster_membership.parquet</text>
 
   <!-- Output 2: MaRaCluster Results -->
-  <!-- Lines from all three modes -->
+  <!-- Lines from both modes -->
   <path d="M 200,720 L 310,810" stroke="#00897B" stroke-width="5" fill="none"/>
-  <path d="M 450,700 L 390,810" stroke="#43A047" stroke-width="5" fill="none"/>
-  <path d="M 700,720 L 440,810" stroke="#8E24AA" stroke-width="5" fill="none"/>
+  <path d="M 550,720 L 440,810" stroke="#8E24AA" stroke-width="5" fill="none"/>
 
-  <circle cx="370" cy="820" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
-  <text x="390" y="817" class="station-label" fill="#F57C00">MaRaCluster Results</text>
-  <text x="390" y="833" class="station-sublabel">clusters_pN.tsv</text>
-
-  <!-- Output 3: Consensus MSP (Legacy MGF only) -->
-  <path d="M 450,700 L 450,880 L 410,900" stroke="#43A047" stroke-width="3" stroke-dasharray="6,3" fill="none"/>
-  <circle cx="370" cy="900" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
-  <text x="390" y="897" class="station-label" fill="#F57C00">Consensus MSP</text>
-  <text x="390" y="913" class="station-sublabel">.msp spectral library</text>
-  <text x="390" y="928" class="skip-label">(Legacy MGF mode only)</text>
+  <circle cx="375" cy="820" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+  <text x="395" y="817" class="station-label" fill="#F57C00">MaRaCluster Results</text>
+  <text x="395" y="833" class="station-sublabel">clusters_pN.tsv</text>
 
   <!-- ==================== FOOTER ==================== -->
-  <text x="450" y="980" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="10" fill="#bbb">SpectrafUSE v0.0.4 -- Nextflow DSL2 Workflow</text>
-  <text x="450" y="995" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="9" fill="#ccc">dat bypass eliminates MGF text inflation (15x size reduction, 12.8M PSMs = 1.3 GB .dat vs 85 GB MGF)</text>
+  <text x="375" y="900" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="10" fill="#bbb">SpectrafUSE v0.0.4 -- Nextflow DSL2 Workflow</text>
+  <text x="375" y="915" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="9" fill="#ccc">Parquet-to-dat: ~100 bytes/spectrum, 12.8M PSMs = 1.3 GB</text>
 
 </svg>

--- a/e2e.config
+++ b/e2e.config
@@ -1,6 +1,6 @@
 /*
  * End-to-end test configuration for spectrafuse pipeline.
- * Uses local pyspectrafuse:local Docker image with bug fixes.
+ * Uses local pyspectrafuse:local Docker image.
  * Test data: PXD014877 (Mycoplasmen, 3608 PSMs, QPX format)
  */
 
@@ -10,17 +10,15 @@ params {
     max_memory  = '8.GB'
     max_cpus    = 4
     max_time    = '2.h'
-    mgf_verbose = false
 }
 
 process {
-    // Override all pyspectrafuse modules to use local image with bug fixes
-    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
-    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
-    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
-    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+    withName: '.*PARQUET_TO_DAT'             { container = 'pyspectrafuse:local' }
+    withName: '.*BUILD_CLUSTER_DB'           { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'      { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'        { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'    { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'          { container = 'pyspectrafuse:local' }
 }
 
 // Running as root — no user mapping needed

--- a/incremental_quality.config
+++ b/incremental_quality.config
@@ -17,7 +17,6 @@ params {
     max_memory  = '8.GB'
     max_cpus    = 4
     max_time    = '6.h'
-    mgf_verbose = false
 
     // MaRaCluster settings
     cluster_threshold     = 30
@@ -28,12 +27,12 @@ params {
 }
 
 process {
-    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
-    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
-    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
-    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+    withName: '.*PARQUET_TO_DAT'             { container = 'pyspectrafuse:local' }
+    withName: '.*BUILD_CLUSTER_DB'           { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'      { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'        { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'    { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'          { container = 'pyspectrafuse:local' }
 }
 
 docker.runOptions = ''

--- a/multi_project.config
+++ b/multi_project.config
@@ -1,26 +1,25 @@
 /*
  * Multi-project clustering configuration.
  * 5 Homo sapiens projects, skip_instrument mode (all instruments clustered together).
- * Uses local pyspectrafuse:local Docker image with all bug fixes.
+ * Uses local pyspectrafuse:local Docker image.
  */
 
 params {
     parquet_dir     = '/srv/data/spectrafuse/multi_batch1'
     outdir          = '/srv/data/spectrafuse/multi_output'
     skip_instrument = true
-    mgf_verbose     = false
     max_memory      = '8.GB'
     max_cpus        = 4
     max_time        = '6.h'
 }
 
 process {
-    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
-    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
-    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
-    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+    withName: '.*PARQUET_TO_DAT'             { container = 'pyspectrafuse:local' }
+    withName: '.*BUILD_CLUSTER_DB'           { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'      { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'        { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'    { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'          { container = 'pyspectrafuse:local' }
 }
 
 docker.runOptions = ''

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,11 +13,9 @@ params {
 
     // Pipeline mode: 'full' (default) or 'incremental'
     mode = 'full'
-    // Use dat bypass for full mode (15x smaller than MGF, recommended)
-    use_dat_bypass = true
     // Path to existing cluster DB (required for incremental mode)
     existing_cluster_db = null
-    // Default species/instrument for dat bypass when QPX metadata grouping is not yet implemented
+    // Default species/instrument when QPX metadata grouping is not yet implemented
     default_species = null
     default_instrument = null
 
@@ -32,8 +30,8 @@ params {
     // Partitioning parameters
     skip_instrument = false // Set to true to cluster all instruments together (no instrument partitioning)
 
-    // Legacy MGF parameters (only used when use_dat_bypass = false or in incremental mode)
-    mgf_verbose = true // Set to true to enable verbose output from the MGF generation step
+    // Incremental mode parameters
+    mgf_verbose = true // Set to true to enable verbose output from spectrum file generation
 
     // MSP format generation parameters (consensus spectrum parameters)
     strategytype = 'best' // Strategy type for consensus spectrum generation

--- a/phase0_split.config
+++ b/phase0_split.config
@@ -12,7 +12,6 @@ params {
     max_memory  = '8.GB'
     max_cpus    = 4
     max_time    = '6.h'
-    mgf_verbose = false
 
     // MaRaCluster settings (same as full 1M baseline)
     cluster_threshold     = 30
@@ -22,12 +21,12 @@ params {
 }
 
 process {
-    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
-    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
-    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
-    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+    withName: '.*PARQUET_TO_DAT'             { container = 'pyspectrafuse:local' }
+    withName: '.*BUILD_CLUSTER_DB'           { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'      { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'        { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'    { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'          { container = 'pyspectrafuse:local' }
 }
 
 docker.runOptions = ''

--- a/pxd004452.config
+++ b/pxd004452.config
@@ -12,7 +12,6 @@ params {
     max_memory  = '16.GB'
     max_cpus    = 4
     max_time    = '12.h'
-    mgf_verbose = false
 
     // MaRaCluster settings
     cluster_threshold     = 30
@@ -23,12 +22,12 @@ params {
 }
 
 process {
-    withName: '.*GENERATE_MGF_FILES'          { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_MSP_FORMAT.*'       { container = 'pyspectrafuse:local' }
-    withName: '.*COMBINE_PROJECT_MSP'         { container = 'pyspectrafuse:local' }
-    withName: '.*GENERATE_CLUSTER_PARQUET.*'  { container = 'pyspectrafuse:local' }
-    withName: '.*EXTRACT_REPRESENTATIVES'     { container = 'pyspectrafuse:local' }
-    withName: '.*MERGE_INCREMENTAL'           { container = 'pyspectrafuse:local' }
+    withName: '.*PARQUET_TO_DAT'             { container = 'pyspectrafuse:local' }
+    withName: '.*BUILD_CLUSTER_DB'           { container = 'pyspectrafuse:local' }
+    withName: '.*GENERATE_MSP_FORMAT.*'      { container = 'pyspectrafuse:local' }
+    withName: '.*COMBINE_PROJECT_MSP'        { container = 'pyspectrafuse:local' }
+    withName: '.*EXTRACT_REPRESENTATIVES'    { container = 'pyspectrafuse:local' }
+    withName: '.*MERGE_INCREMENTAL'          { container = 'pyspectrafuse:local' }
 }
 
 docker.runOptions = ''

--- a/workflows/spectrafuse.nf
+++ b/workflows/spectrafuse.nf
@@ -4,35 +4,30 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Spectral clustering using MaRaCluster.
 
-    Three modes (params.mode + params.use_dat_bypass):
-    - Full + dat bypass (default): Parquet → .dat → MaRaCluster → Cluster DB
-    - Full + legacy MGF: Parquet → MGF → MaRaCluster → MSP + Cluster Parquet
+    Two modes (params.mode):
+    - Full (default): Parquet → .dat → MaRaCluster → Cluster DB
     - Incremental: Extract reps → cluster with new data → merge back
 
     All modes partition by species/instrument/charge.
 ----------------------------------------------------------------------------------------
 */
 
-// ── Full mode: dat bypass ──
+// ── Full mode: parquet-to-dat ──
 include { PARQUET_TO_DAT }       from '../modules/local/pyspectrafuse/parquet_to_dat/main'
 include { RUN_MARACLUSTER_DAT }  from '../modules/local/maracluster/run_maracluster_dat/main'
 include { BUILD_CLUSTER_DB }     from '../modules/local/pyspectrafuse/build_cluster_db/main'
 
-// ── Full mode: legacy MGF (also used for incremental new data) ──
+// ── Incremental mode ──
 include { GENERATE_MGF_FILES }       from '../modules/local/quantmsio2mgf/generate_mgf_files/main'
 include { RUN_MARACLUSTER }          from '../modules/local/maracluster/run_maracluster/main'
-include { GENERATE_MSP_FORMAT }      from '../modules/local/pyspectrafuse/generate_msp_format/main'
-include { GENERATE_CLUSTER_PARQUET } from '../modules/local/pyspectrafuse/generate_cluster_parquet/main'
-
-// ── Incremental mode ──
 include { EXTRACT_REPRESENTATIVES }  from '../modules/local/pyspectrafuse/extract_representatives/main'
 include { MERGE_INCREMENTAL }        from '../modules/local/pyspectrafuse/merge_incremental/main'
 
 
-workflow SPECTRAFUSE_DAT {
+workflow SPECTRAFUSE_FULL {
     /*
-     * FULL MODE — DAT BYPASS (recommended)
-     * Parquet → .dat (15x smaller) → MaRaCluster -D → Cluster DB
+     * FULL MODE
+     * Parquet → .dat → MaRaCluster -D → Cluster DB
      */
     take:
     ch_projects
@@ -122,62 +117,6 @@ workflow SPECTRAFUSE_DAT {
 }
 
 
-workflow SPECTRAFUSE_MGF {
-    /*
-     * FULL MODE — LEGACY MGF
-     * Parquet → MGF → MaRaCluster → MSP + Cluster Parquet
-     */
-    take:
-    ch_projects
-    ch_parquet_dir
-
-    main:
-    ch_versions = channel.empty()
-
-    ch_projects
-        .map { project_dir -> [ [ id: project_dir.baseName ], project_dir ] }
-        .set { ch_projects_with_meta }
-
-    GENERATE_MGF_FILES(ch_projects_with_meta)
-    ch_versions = ch_versions.mix(GENERATE_MGF_FILES.out.versions)
-
-    GENERATE_MGF_FILES.out.mgf_files
-        .flatten()
-        .map { file ->
-            def pathParts = file.toString().split('/')
-            def idx = pathParts.findIndexOf { it == 'mgf_output' }
-            if (idx == -1) return null
-
-            def species = pathParts[idx + 1]
-            def instrument = params.skip_instrument ? 'all_instruments' : pathParts[idx + 2]
-            def charge = pathParts[idx + 3]
-            def key = params.skip_instrument
-                ? "${species}/${charge}" : "${species}/${instrument}/${charge}"
-            def id = key.replaceAll(/[\\/]/, '__').replaceAll(/\s+/, '_')
-            def meta = [ id: id, species: species, instrument: instrument, charge: charge ]
-            return [key, meta, file]
-        }
-        .filter { it != null }
-        .groupTuple(by: 0)
-        .map { _key, meta_list, files -> [meta_list[0], files] }
-        .set { ch_grouped_mgf }
-
-    RUN_MARACLUSTER(ch_grouped_mgf)
-    ch_versions = ch_versions.mix(RUN_MARACLUSTER.out.versions)
-
-    GENERATE_MSP_FORMAT(ch_parquet_dir, RUN_MARACLUSTER.out.maracluster_results)
-    ch_versions = ch_versions.mix(GENERATE_MSP_FORMAT.out.versions)
-
-    GENERATE_CLUSTER_PARQUET(ch_parquet_dir, RUN_MARACLUSTER.out.maracluster_results)
-    ch_versions = ch_versions.mix(GENERATE_CLUSTER_PARQUET.out.versions)
-
-    emit:
-    maracluster_results = RUN_MARACLUSTER.out.maracluster_results
-    cluster_parquet     = GENERATE_CLUSTER_PARQUET.out.cluster_parquet_files
-    versions            = ch_versions
-}
-
-
 workflow SPECTRAFUSE_INCREMENTAL {
     /*
      * INCREMENTAL MODE
@@ -209,7 +148,7 @@ workflow SPECTRAFUSE_INCREMENTAL {
     )
     ch_versions = ch_versions.mix(EXTRACT_REPRESENTATIVES.out.versions)
 
-    // Step 2: Convert new data to MGF
+    // Step 2: Convert new data to spectrum files
     ch_projects
         .map { project_dir -> [ [ id: project_dir.baseName ], project_dir ] }
         .set { ch_projects_with_meta }
@@ -217,7 +156,7 @@ workflow SPECTRAFUSE_INCREMENTAL {
     GENERATE_MGF_FILES(ch_projects_with_meta)
     ch_versions = ch_versions.mix(GENERATE_MGF_FILES.out.versions)
 
-    // Step 3: Group new MGFs by partition key
+    // Step 3: Group new spectra by partition key
     GENERATE_MGF_FILES.out.mgf_files
         .flatten()
         .map { file ->
@@ -233,18 +172,18 @@ workflow SPECTRAFUSE_INCREMENTAL {
         }
         .filter { it != null }
         .groupTuple()
-        .set { ch_new_mgf }
+        .set { ch_new_spectra }
 
-    // Combine reps + new MGFs
+    // Combine reps + new spectra
     EXTRACT_REPRESENTATIVES.out.representative_mgf
         .map { meta, mgf -> [meta.id, meta, mgf] }
-        .join(ch_new_mgf)
-        .map { _id, meta, rep_mgf, new_mgfs ->
-            [meta, [rep_mgf, new_mgfs].flatten()]
+        .join(ch_new_spectra)
+        .map { _id, meta, rep_mgf, new_files ->
+            [meta, [rep_mgf, new_files].flatten()]
         }
-        .set { ch_combined_mgf }
+        .set { ch_combined_spectra }
 
-    RUN_MARACLUSTER(ch_combined_mgf)
+    RUN_MARACLUSTER(ch_combined_spectra)
     ch_versions = ch_versions.mix(RUN_MARACLUSTER.out.versions)
 
     // Step 4: Merge
@@ -284,16 +223,11 @@ workflow SPECTRAFUSE {
         ch_results = SPECTRAFUSE_INCREMENTAL.out.maracluster_results
         ch_parquet = SPECTRAFUSE_INCREMENTAL.out.cluster_parquet
         ch_versions = SPECTRAFUSE_INCREMENTAL.out.versions
-    } else if (params.use_dat_bypass) {
-        SPECTRAFUSE_DAT(ch_projects, ch_parquet_dir)
-        ch_results = SPECTRAFUSE_DAT.out.maracluster_results
-        ch_parquet = SPECTRAFUSE_DAT.out.cluster_parquet
-        ch_versions = SPECTRAFUSE_DAT.out.versions
     } else {
-        SPECTRAFUSE_MGF(ch_projects, ch_parquet_dir)
-        ch_results = SPECTRAFUSE_MGF.out.maracluster_results
-        ch_parquet = SPECTRAFUSE_MGF.out.cluster_parquet
-        ch_versions = SPECTRAFUSE_MGF.out.versions
+        SPECTRAFUSE_FULL(ch_projects, ch_parquet_dir)
+        ch_results = SPECTRAFUSE_FULL.out.maracluster_results
+        ch_parquet = SPECTRAFUSE_FULL.out.cluster_parquet
+        ch_versions = SPECTRAFUSE_FULL.out.versions
     }
 
     emit:


### PR DESCRIPTION
- Remove SPECTRAFUSE_MGF workflow entirely, rename SPECTRAFUSE_DAT to SPECTRAFUSE_FULL
- Remove use_dat_bypass param — full mode always uses parquet-to-dat
- Update all config files: remove mgf_verbose, update process selectors
- Update README: no MGF references in workflow description
- Simplify SVG diagram to 2 modes (full + incremental)
- Clean up test.config and all custom configs