### PR TITLE
Feature/dat bypass workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,31 +18,6 @@ quantms has reanalyzed an extensive number of datasets with almost 1 billion MS/
 
 SpectrafUSE is a single pipeline. New QPX projects are always converted to MaRaCluster's `.dat` binary format (~100 bytes/spectrum), sliced into precursor m/z windows, clustered, and written to a cluster DB plus an MSP spectral library. If `--existing_cluster_db <path>` is supplied, representative spectra from that DB are extracted to `.dat` and clustered alongside the new data — the rest of the pipeline is identical, and the final step merges into the existing DB instead of writing a fresh one.
 
-```
-  (--existing_cluster_db)      ┌─ EXTRACT_REPS_DAT ─┐
-                               │                    │
-  new QPX projects ─────────── ├─ PARQUET_TO_DAT ───┤
-                               └────────────────────┴──┐
-                                                       ▼
-                                            CONCAT_DAT_FILES   (per species/[instrument]/charge)
-                                                       │
-                                                       ▼
-                                           SPLIT_MZ_WINDOWS    (default: 300 Da, 1 Da overlap)
-                                                       │
-                                                       ▼
-                                         RUN_MARACLUSTER_DAT   (parallel per window)
-                                                       │
-                                                       ▼
-                                           MERGE_MZ_WINDOWS    (reconcile overlap zones)
-                                                       │
-                                                       ▼
-                                 ┌──────────── cluster TSV + scan_titles ──────────┐
-                                 ▼                                                 ▼
-                      BUILD_CLUSTER_DB           ▲       GENERATE_MSP_FORMAT (*.msp.gz per partition)
-                      MERGE_INTO_EXISTING_DB     │
-                                (if --existing_cluster_db)
-```
-
 1. **Parquet → Dat** (`PARQUET_TO_DAT`): Converts PSM parquet files directly to MaRaCluster's binary `.dat` format. Replicates MaRaCluster's internal binning (`bin = floor(mz / 1.000508 + 0.32)`, top-40 peaks). ~100 bytes/spectrum.
 
 2. **Representative Extraction** (`EXTRACT_REPS_DAT`, *only with* `--existing_cluster_db`): Reads each existing `cluster_metadata.parquet`, writes one consensus spectrum per cluster to `.dat` with a `rep:{cluster_id}` scan title — becomes another source for the same clustering pipeline.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@ quantms has reanalyzed an extensive number of datasets with almost 1 billion MS/
 
 ## Workflow Overview
 
-> A diagram will be added here once the unified workflow figure is drawn.
-> In the meantime, see the ASCII flow below and the design spec at
-> [`docs/workflow_diagram_spec.md`](docs/workflow_diagram_spec.md).
->
-> File formats (QPX inputs, the `.dat` binary, `.scan_titles.txt`,
-> cluster-DB parquets, MSP, and the pre-existing cluster DB layout
-> expected by `--existing_cluster_db`) are documented in
-> [`docs/formats.md`](docs/formats.md).
+![SpectrafUSE Workflow](docs/images/spectrafuse_workflow.svg)
+
+> See [`docs/formats.md`](docs/formats.md) for the exact structure of every
+> file the pipeline reads and writes — QPX inputs, the `.dat` binary,
+> `.scan_titles.txt`, cluster-DB parquets, MSP, and the pre-existing cluster
+> DB layout expected by `--existing_cluster_db`.
 
 
 SpectrafUSE is a single pipeline. New QPX projects are always converted to MaRaCluster's `.dat` binary format (~100 bytes/spectrum), sliced into precursor m/z windows, clustered, and written to a cluster DB plus an MSP spectral library. If `--existing_cluster_db <path>` is supplied, representative spectra from that DB are extracted to `.dat` and clustered alongside the new data — the rest of the pipeline is identical, and the final step merges into the existing DB instead of writing a fresh one.

--- a/docs/images/spectrafuse_workflow.svg
+++ b/docs/images/spectrafuse_workflow.svg
@@ -67,7 +67,7 @@
   </g>
   <text x="175" y="268" text-anchor="middle" class="sublabel">one consensus spectrum per cluster</text>
   <text x="175" y="282" text-anchor="middle" class="sublabel" font-style="italic">scan_title = rep:{cluster_id}</text>
-  <text x="265" y="238" class="parallel-note">× partitions</text>
+  <text x="280" y="228" class="parallel-note">× partitions</text>
 
   <!-- PARQUET_TO_DAT — parallel per QPX project -->
   <g transform="translate(560, 224)">
@@ -79,14 +79,14 @@
   </g>
   <text x="560" y="268" text-anchor="middle" class="sublabel">convert PSMs to MaRaCluster .dat</text>
   <text x="560" y="282" text-anchor="middle" class="sublabel" font-style="italic">~100 bytes/spectrum</text>
-  <text x="650" y="238" class="parallel-note">× projects</text>
+  <text x="665" y="228" class="parallel-note">× projects</text>
 
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
   <!--                  SHARED CLUSTERING SPINE (row 3+)                            -->
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
 
-  <!-- Partition box -->
-  <rect x="120" y="330" width="660" height="480" rx="12" fill="#F5FBFA" stroke="#E0F2F1" stroke-width="1"/>
+  <!-- Partition box — encompasses every step that runs once per partition -->
+  <rect x="120" y="330" width="660" height="600" rx="12" fill="#F5FBFA" stroke="#E0F2F1" stroke-width="1"/>
   <text x="450" y="352" text-anchor="middle" class="caption">per partition — species / charge (or species / instrument / charge when <tspan font-family="'Courier New', monospace" font-size="10.5">--skip_instrument</tspan> is off)</text>
 
   <!-- Two streams converge on CONCAT -->
@@ -102,7 +102,7 @@
     <text x="0" y="3" text-anchor="middle" class="badge">CONCAT_DAT_FILES</text>
   </g>
   <text x="450" y="444" text-anchor="middle" class="sublabel">concatenate .dat per charge (reps + new data, renumber scannr)</text>
-  <text x="560" y="414" class="parallel-note">× partitions</text>
+  <text x="565" y="404" class="parallel-note">× partitions</text>
   <line x1="450" y1="458" x2="450" y2="490" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
   <!-- SPLIT_MZ_WINDOWS -->
@@ -114,7 +114,7 @@
     <text x="0" y="3" text-anchor="middle" class="badge">SPLIT_MZ_WINDOWS</text>
   </g>
   <text x="450" y="548" text-anchor="middle" class="sublabel">precursor m/z windowing — default 300 Da, 1 Da overlap</text>
-  <text x="560" y="518" class="parallel-note">× partitions</text>
+  <text x="565" y="508" class="parallel-note">× partitions</text>
   <line x1="450" y1="562" x2="450" y2="594" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
   <!-- RUN_MARACLUSTER_DAT — the highly-parallel step -->
@@ -129,7 +129,7 @@
     <text x="0" y="3" text-anchor="middle" class="badge">RUN_MARACLUSTER_DAT</text>
   </g>
   <text x="450" y="662" text-anchor="middle" class="sublabel">cluster each window with MaRaCluster (-D, reads .dat directly)</text>
-  <text x="570" y="622" class="parallel-note" fill="#BF360C">× partitions × windows</text>
+  <text x="585" y="612" class="parallel-note" fill="#BF360C">× partitions × windows</text>
   <line x1="450" y1="676" x2="450" y2="708" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
   <!-- MERGE_MZ_WINDOWS -->
@@ -141,7 +141,7 @@
     <text x="0" y="3" text-anchor="middle" class="badge">MERGE_MZ_WINDOWS</text>
   </g>
   <text x="450" y="766" text-anchor="middle" class="sublabel">reconcile overlap zones (lowest-window-index wins)</text>
-  <text x="560" y="736" class="parallel-note">× partitions</text>
+  <text x="565" y="726" class="parallel-note">× partitions</text>
 
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
   <!--                           BUILD + MSP (row 4)                               -->
@@ -162,7 +162,7 @@
   </g>
   <text x="310" y="900" text-anchor="middle" class="sublabel">cluster DB parquets · resolves rep: IDs when merging</text>
   <text x="310" y="914" text-anchor="middle" class="sublabel" font-style="italic">provenance: is_reused_cluster · source_datasets</text>
-  <text x="310" y="878" text-anchor="middle" class="parallel-note">× partitions</text>
+  <text x="425" y="858" class="parallel-note">× partitions</text>
 
   <!-- GENERATE_MSP_FORMAT -->
   <g transform="translate(590, 854)">
@@ -174,7 +174,7 @@
   </g>
   <text x="590" y="900" text-anchor="middle" class="sublabel">consensus spectral library</text>
   <text x="590" y="914" text-anchor="middle" class="sublabel" font-style="italic">*.msp.gz per partition</text>
-  <text x="590" y="878" text-anchor="middle" class="parallel-note">× partitions</text>
+  <text x="700" y="858" class="parallel-note">× partitions</text>
 
   <!-- Arrows from the two tail processes to the output cylinders -->
   <line x1="310" y1="924" x2="310" y2="960" stroke="#F57C00" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-out)"/>
@@ -183,11 +183,11 @@
   <!-- ══════ OUTPUTS ══════ -->
   <g transform="translate(310, 976)">
     <circle cx="0" cy="0" r="9" fill="none" stroke="#F57C00" stroke-width="2.5"/>
-    <text x="0" y="-16" text-anchor="middle" class="label" fill="#F57C00">Cluster DB</text>
+    <text x="0" y="26" text-anchor="middle" class="label" fill="#F57C00">Cluster DB</text>
   </g>
   <g transform="translate(590, 976)">
     <circle cx="0" cy="0" r="9" fill="none" stroke="#F57C00" stroke-width="2.5"/>
-    <text x="0" y="-16" text-anchor="middle" class="label" fill="#F57C00">MSP Library</text>
+    <text x="0" y="26" text-anchor="middle" class="label" fill="#F57C00">MSP Library</text>
   </g>
 
   <!-- ══════ LEGEND (bottom-left, no longer overlaps inputs) ══════ -->

--- a/docs/images/spectrafuse_workflow.svg
+++ b/docs/images/spectrafuse_workflow.svg
@@ -1,13 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 880" width="820" height="880">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1020" width="900" height="1020">
   <defs>
     <style>
+      .title     { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 20px; font-weight: 700; fill: #263238; }
+      .subtitle  { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 11px; fill: #90A4AE; }
       .label     { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 13px; font-weight: 600; fill: #263238; }
-      .sublabel  { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10.5px; fill: #78909C; }
-      .badge     { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 8.5px; font-weight: 700; fill: #fff; letter-spacing: 0.4px; }
-      .opt-badge { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 8.5px; font-weight: 700; fill: #fff; letter-spacing: 0.4px; }
-      .caption   { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10.5px; font-style: italic; fill: #607D8B; }
-      .legend-title { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 11.5px; font-weight: 700; fill: #37474F; }
-      .legend-text  { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10.5px; fill: #607D8B; }
+      .sublabel  { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 11px; fill: #78909C; }
+      .badge     { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 9px; font-weight: 700; fill: #fff; letter-spacing: 0.4px; }
+      .opt-badge { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 9px; font-weight: 700; fill: #fff; letter-spacing: 0.4px; }
+      .caption   { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 11px; font-style: italic; fill: #607D8B; }
+      .parallel-note { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10.5px; font-weight: 700; fill: #D84315; letter-spacing: 0.3px; }
+      .legend-title  { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 700; fill: #37474F; }
+      .legend-text   { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10.5px; fill: #607D8B; }
     </style>
     <marker id="arrow-main" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="5" markerHeight="5" orient="auto">
       <path d="M0,0 L10,5 L0,10 z" fill="#00897B"/>
@@ -20,162 +23,192 @@
     </marker>
   </defs>
 
-  <rect width="820" height="880" fill="#ffffff"/>
+  <rect width="900" height="1020" fill="#ffffff"/>
 
   <!-- ══════ TITLE ══════ -->
-  <text x="410" y="34" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="19" font-weight="bold" fill="#263238">SpectrafUSE Pipeline</text>
-  <text x="410" y="52" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="10.5" fill="#90A4AE">One workflow. --existing_cluster_db is just an optional extra input.</text>
-
-  <!-- ══════ LEGEND ══════ -->
-  <g transform="translate(620, 76)">
-    <rect x="-8" y="-14" width="192" height="88" rx="6" fill="#FAFAFA" stroke="#ECEFF1" stroke-width="1"/>
-    <text x="0" y="0" class="legend-title">LEGEND</text>
-    <circle cx="8" cy="18" r="6" fill="#00897B"/>
-    <text x="22" y="22" class="legend-text">Process</text>
-    <circle cx="8" cy="38" r="6" fill="none" stroke="#F57C00" stroke-width="2"/>
-    <text x="22" y="42" class="legend-text">Output</text>
-    <line x1="2" y1="58" x2="18" y2="58" stroke="#9E9E9E" stroke-width="2.5" stroke-dasharray="5,3"/>
-    <text x="22" y="62" class="legend-text">Optional (--existing_cluster_db)</text>
-  </g>
+  <text x="450" y="36" text-anchor="middle" class="title">SpectrafUSE Pipeline</text>
+  <text x="450" y="54" text-anchor="middle" class="subtitle">One workflow — supply <tspan font-family="'Courier New', monospace" font-size="10">--existing_cluster_db</tspan> to merge into a prior cluster DB instead of starting fresh.</text>
 
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
-  <!--                          INPUTS                                             -->
+  <!--                           INPUTS (row 1)                                    -->
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
-
-  <!-- Primary input: QPX -->
-  <g transform="translate(410, 110)">
-    <circle cx="0" cy="0" r="9" fill="#1565C0" stroke="#fff" stroke-width="2"/>
-    <text x="16" y="-2" class="label" fill="#1565C0">QPX Parquet Projects</text>
-    <text x="16" y="14" class="sublabel">.psm.parquet · .run.parquet · .sample.parquet</text>
-  </g>
 
   <!-- Optional input: existing cluster DB (left, dashed) -->
-  <g transform="translate(120, 110)">
-    <circle cx="0" cy="0" r="8" fill="none" stroke="#9E9E9E" stroke-width="2"/>
-    <text x="-14" y="-2" text-anchor="end" class="label" fill="#616161">--existing_cluster_db</text>
-    <text x="-14" y="14" text-anchor="end" class="sublabel">prior cluster_metadata.parquet</text>
+  <g transform="translate(175, 110)">
+    <circle cx="0" cy="0" r="10" fill="none" stroke="#9E9E9E" stroke-width="2"/>
+    <text x="0" y="28" text-anchor="middle" class="label" fill="#616161">--existing_cluster_db</text>
+    <text x="0" y="42" text-anchor="middle" class="sublabel">prior cluster_metadata.parquet (optional)</text>
+  </g>
+
+  <!-- Primary input: QPX -->
+  <g transform="translate(560, 110)">
+    <circle cx="0" cy="0" r="10" fill="#1565C0" stroke="#fff" stroke-width="2"/>
+    <text x="0" y="28" text-anchor="middle" class="label" fill="#1565C0">QPX Parquet Projects</text>
+    <text x="0" y="42" text-anchor="middle" class="sublabel">.psm.parquet · .run.parquet · .sample.parquet</text>
   </g>
 
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
-  <!--                          PER-SOURCE CONVERSION                              -->
+  <!--                           PER-SOURCE CONVERSION (row 2)                     -->
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
 
-  <!-- QPX → PARQUET_TO_DAT -->
-  <line x1="410" y1="119" x2="410" y2="172" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+  <!-- Arrows from inputs down -->
+  <line x1="175" y1="124" x2="175" y2="206" stroke="#9E9E9E" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="5,3" marker-end="url(#arrow-opt)"/>
+  <line x1="560" y1="124" x2="560" y2="206" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
-  <!-- existing_cluster_db → EXTRACT_REPS_DAT (dashed) -->
-  <line x1="120" y1="118" x2="120" y2="172" stroke="#9E9E9E" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="5,3" marker-end="url(#arrow-opt)"/>
-
-  <!-- EXTRACT_REPS_DAT (optional, dashed box) -->
-  <g transform="translate(120, 190)">
-    <circle cx="0" cy="0" r="9" fill="#ECEFF1" stroke="#9E9E9E" stroke-width="2" stroke-dasharray="3,2"/>
-    <rect x="-74" y="18" width="148" height="17" rx="3" fill="#9E9E9E"/>
-    <text x="0" y="31" text-anchor="middle" class="opt-badge">EXTRACT_REPS_DAT</text>
-    <text x="0" y="54" text-anchor="middle" class="sublabel">one consensus spectrum per cluster</text>
-    <text x="0" y="68" text-anchor="middle" class="sublabel" fill="#9E9E9E" font-style="italic">scan_title = rep:{cluster_id}</text>
+  <!-- EXTRACT_REPS_DAT — parallel per existing-partition (shadows offset right-down) -->
+  <g transform="translate(175, 224)">
+    <!-- parallel shadow copies -->
+    <rect x="-82" y="-10" width="164" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" stroke-dasharray="3,2" transform="translate(10, 10)" opacity="0.6"/>
+    <rect x="-82" y="-10" width="164" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" stroke-dasharray="3,2" transform="translate(5, 5)" opacity="0.8"/>
+    <!-- primary dashed box -->
+    <rect x="-82" y="-10" width="164" height="20" rx="4" fill="#FAFAFA" stroke="#9E9E9E" stroke-width="2" stroke-dasharray="3,2"/>
+    <rect x="-78" y="-8" width="156" height="16" rx="3" fill="#9E9E9E"/>
+    <text x="0" y="3" text-anchor="middle" class="opt-badge">EXTRACT_REPS_DAT</text>
   </g>
+  <text x="175" y="268" text-anchor="middle" class="sublabel">one consensus spectrum per cluster</text>
+  <text x="175" y="282" text-anchor="middle" class="sublabel" font-style="italic">scan_title = rep:{cluster_id}</text>
+  <text x="265" y="238" class="parallel-note">× partitions</text>
 
-  <!-- PARQUET_TO_DAT -->
-  <g transform="translate(410, 190)">
-    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
-    <rect x="-74" y="18" width="148" height="17" rx="3" fill="#00897B"/>
-    <text x="0" y="31" text-anchor="middle" class="badge">PARQUET_TO_DAT</text>
-    <text x="0" y="54" text-anchor="middle" class="sublabel">~100 bytes/spectrum</text>
-    <text x="0" y="68" text-anchor="middle" class="sublabel">.dat + .scan_info + .scan_titles</text>
+  <!-- PARQUET_TO_DAT — parallel per QPX project -->
+  <g transform="translate(560, 224)">
+    <rect x="-82" y="-10" width="164" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(10, 10)" opacity="0.6"/>
+    <rect x="-82" y="-10" width="164" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(5, 5)" opacity="0.8"/>
+    <rect x="-82" y="-10" width="164" height="20" rx="4" fill="#fff" stroke="#00897B" stroke-width="2"/>
+    <rect x="-78" y="-8" width="156" height="16" rx="3" fill="#00897B"/>
+    <text x="0" y="3" text-anchor="middle" class="badge">PARQUET_TO_DAT</text>
   </g>
+  <text x="560" y="268" text-anchor="middle" class="sublabel">convert PSMs to MaRaCluster .dat</text>
+  <text x="560" y="282" text-anchor="middle" class="sublabel" font-style="italic">~100 bytes/spectrum</text>
+  <text x="650" y="238" class="parallel-note">× projects</text>
 
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
-  <!--                          SHARED CLUSTERING SPINE                            -->
+  <!--                  SHARED CLUSTERING SPINE (row 3+)                            -->
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
 
-  <!-- Both conversions flow into CONCAT_DAT_FILES (center) -->
-  <path d="M 120,255 C 120,285 265,290 390,310" fill="none" stroke="#9E9E9E" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="5,3" marker-end="url(#arrow-opt)"/>
-  <line x1="410" y1="268" x2="410" y2="313" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+  <!-- Partition box -->
+  <rect x="120" y="330" width="660" height="480" rx="12" fill="#F5FBFA" stroke="#E0F2F1" stroke-width="1"/>
+  <text x="450" y="352" text-anchor="middle" class="caption">per partition — species / charge (or species / instrument / charge when <tspan font-family="'Courier New', monospace" font-size="10.5">--skip_instrument</tspan> is off)</text>
 
-  <!-- Partition box subtle background -->
-  <rect x="120" y="325" width="580" height="445" rx="12" fill="#F5FBFA" stroke="#E0F2F1" stroke-width="1"/>
-  <text x="410" y="345" text-anchor="middle" class="caption">per partition — species / charge (or species / instrument / charge)</text>
+  <!-- Two streams converge on CONCAT -->
+  <path d="M 175,290 C 175,330 280,350 438,388" fill="none" stroke="#9E9E9E" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="5,3" marker-end="url(#arrow-opt)"/>
+  <path d="M 560,290 C 560,330 500,350 462,388" fill="none" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
   <!-- CONCAT_DAT_FILES -->
-  <g transform="translate(410, 378)">
-    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
-    <rect x="-74" y="-33" width="148" height="17" rx="3" fill="#00897B"/>
-    <text x="0" y="-20" text-anchor="middle" class="badge">CONCAT_DAT_FILES</text>
-    <text x="16" y="-2" class="label">Concatenate .dat per charge</text>
-    <text x="16" y="14" class="sublabel">reps + new data, renumber scannr</text>
+  <g transform="translate(450, 400)">
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(10, 10)" opacity="0.6"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(5, 5)" opacity="0.8"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#fff" stroke="#00897B" stroke-width="2"/>
+    <rect x="-86" y="-8" width="172" height="16" rx="3" fill="#00897B"/>
+    <text x="0" y="3" text-anchor="middle" class="badge">CONCAT_DAT_FILES</text>
   </g>
-  <line x1="410" y1="387" x2="410" y2="440" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+  <text x="450" y="444" text-anchor="middle" class="sublabel">concatenate .dat per charge (reps + new data, renumber scannr)</text>
+  <text x="560" y="414" class="parallel-note">× partitions</text>
+  <line x1="450" y1="458" x2="450" y2="490" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
   <!-- SPLIT_MZ_WINDOWS -->
-  <g transform="translate(410, 458)">
-    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
-    <rect x="-74" y="-33" width="148" height="17" rx="3" fill="#00897B"/>
-    <text x="0" y="-20" text-anchor="middle" class="badge">SPLIT_MZ_WINDOWS</text>
-    <text x="16" y="-2" class="label">m/z windowing</text>
-    <text x="16" y="14" class="sublabel">300 Da windows, 1 Da overlap</text>
+  <g transform="translate(450, 504)">
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(10, 10)" opacity="0.6"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(5, 5)" opacity="0.8"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#fff" stroke="#00897B" stroke-width="2"/>
+    <rect x="-86" y="-8" width="172" height="16" rx="3" fill="#00897B"/>
+    <text x="0" y="3" text-anchor="middle" class="badge">SPLIT_MZ_WINDOWS</text>
   </g>
-  <line x1="410" y1="467" x2="410" y2="520" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+  <text x="450" y="548" text-anchor="middle" class="sublabel">precursor m/z windowing — default 300 Da, 1 Da overlap</text>
+  <text x="560" y="518" class="parallel-note">× partitions</text>
+  <line x1="450" y1="562" x2="450" y2="594" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
-  <!-- RUN_MARACLUSTER_DAT (parallel fan-out) -->
-  <g transform="translate(410, 538)">
-    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
-    <circle cx="-22" cy="0" r="5" fill="#00897B" opacity="0.35"/>
-    <circle cx="-44" cy="0" r="4" fill="#00897B" opacity="0.2"/>
-    <circle cx="22" cy="0" r="5" fill="#00897B" opacity="0.35"/>
-    <circle cx="44" cy="0" r="4" fill="#00897B" opacity="0.2"/>
-    <rect x="-74" y="-33" width="148" height="17" rx="3" fill="#00897B"/>
-    <text x="0" y="-20" text-anchor="middle" class="badge">RUN_MARACLUSTER_DAT</text>
-    <text x="60" y="-2" class="label">MaRaCluster per window</text>
-    <text x="60" y="14" class="sublabel">parallel — one task per window</text>
+  <!-- RUN_MARACLUSTER_DAT — the highly-parallel step -->
+  <g transform="translate(450, 608)">
+    <!-- Extra parallel shadows — more than the other steps, indicating high parallelism -->
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFAB91" stroke="#BF360C" stroke-width="1.5" transform="translate(18, 18)" opacity="0.4"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFAB91" stroke="#BF360C" stroke-width="1.5" transform="translate(14, 14)" opacity="0.55"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFAB91" stroke="#BF360C" stroke-width="1.5" transform="translate(10, 10)" opacity="0.7"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFAB91" stroke="#BF360C" stroke-width="1.5" transform="translate(5, 5)" opacity="0.85"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#fff" stroke="#00897B" stroke-width="2"/>
+    <rect x="-86" y="-8" width="172" height="16" rx="3" fill="#00897B"/>
+    <text x="0" y="3" text-anchor="middle" class="badge">RUN_MARACLUSTER_DAT</text>
   </g>
-  <line x1="410" y1="547" x2="410" y2="600" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+  <text x="450" y="662" text-anchor="middle" class="sublabel">cluster each window with MaRaCluster (-D, reads .dat directly)</text>
+  <text x="570" y="622" class="parallel-note" fill="#BF360C">× partitions × windows</text>
+  <line x1="450" y1="676" x2="450" y2="708" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
   <!-- MERGE_MZ_WINDOWS -->
-  <g transform="translate(410, 618)">
-    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
-    <rect x="-74" y="-33" width="148" height="17" rx="3" fill="#00897B"/>
-    <text x="0" y="-20" text-anchor="middle" class="badge">MERGE_MZ_WINDOWS</text>
-    <text x="16" y="-2" class="label">Reconcile overlap zones</text>
-    <text x="16" y="14" class="sublabel">deterministic lowest-window wins</text>
+  <g transform="translate(450, 722)">
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(10, 10)" opacity="0.6"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(5, 5)" opacity="0.8"/>
+    <rect x="-90" y="-10" width="180" height="20" rx="4" fill="#fff" stroke="#00897B" stroke-width="2"/>
+    <rect x="-86" y="-8" width="172" height="16" rx="3" fill="#00897B"/>
+    <text x="0" y="3" text-anchor="middle" class="badge">MERGE_MZ_WINDOWS</text>
   </g>
-  <line x1="410" y1="627" x2="410" y2="680" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
-
-  <!-- BUILD_CLUSTER_DB (or MERGE_INTO_EXISTING_DB) -->
-  <g transform="translate(410, 698)">
-    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
-    <rect x="-118" y="-33" width="236" height="17" rx="3" fill="#00897B"/>
-    <text x="0" y="-20" text-anchor="middle" class="badge">BUILD_CLUSTER_DB  /  MERGE_INTO_EXISTING_DB</text>
-    <text x="16" y="-2" class="label">Build cluster DB</text>
-    <text x="16" y="14" class="sublabel">resolve rep: cluster_ids; is_reused_cluster + source_datasets</text>
-  </g>
+  <text x="450" y="766" text-anchor="middle" class="sublabel">reconcile overlap zones (lowest-window-index wins)</text>
+  <text x="560" y="736" class="parallel-note">× partitions</text>
 
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
-  <!--                          OUTPUTS                                            -->
+  <!--                           BUILD + MSP (row 4)                               -->
   <!-- ══════════════════════════════════════════════════════════════════════════ -->
 
-  <!-- Split the flow into cluster DB + MSP outputs. GENERATE_MSP_FORMAT reads the
-       same merged-clusters + scan_titles, so show it as a sibling of the DB step. -->
-  <path d="M 410,707 C 410,750 290,770 230,790" fill="none" stroke="#F57C00" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-out)"/>
-  <path d="M 410,707 C 410,750 530,770 590,790" fill="none" stroke="#F57C00" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-out)"/>
+  <line x1="450" y1="780" x2="450" y2="820" stroke="#00897B" stroke-width="3.5" stroke-linecap="round"/>
+  <!-- split into two siblings -->
+  <path d="M 450,820 L 310,840" fill="none" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+  <path d="M 450,820 L 590,840" fill="none" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
 
-  <!-- Output 1: Cluster DB -->
-  <g transform="translate(230, 810)">
-    <circle cx="0" cy="0" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
-    <text x="16" y="-2" class="label" fill="#F57C00">Cluster DB</text>
-    <text x="16" y="14" class="sublabel">cluster_metadata.parquet</text>
-    <text x="16" y="28" class="sublabel">psm_cluster_membership.parquet</text>
-    <text x="16" y="42" class="sublabel" fill="#F57C00" font-style="italic">partitioned by species/[instrument]/charge</text>
+  <!-- BUILD_CLUSTER_DB / MERGE_INTO_EXISTING_DB -->
+  <g transform="translate(310, 854)">
+    <rect x="-100" y="-10" width="200" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(10, 10)" opacity="0.6"/>
+    <rect x="-100" y="-10" width="200" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(5, 5)" opacity="0.8"/>
+    <rect x="-100" y="-10" width="200" height="20" rx="4" fill="#fff" stroke="#00897B" stroke-width="2"/>
+    <rect x="-96" y="-8" width="192" height="16" rx="3" fill="#00897B"/>
+    <text x="0" y="3" text-anchor="middle" class="badge">BUILD_CLUSTER_DB / MERGE_INTO_EXISTING_DB</text>
+  </g>
+  <text x="310" y="900" text-anchor="middle" class="sublabel">cluster DB parquets · resolves rep: IDs when merging</text>
+  <text x="310" y="914" text-anchor="middle" class="sublabel" font-style="italic">provenance: is_reused_cluster · source_datasets</text>
+  <text x="310" y="878" text-anchor="middle" class="parallel-note">× partitions</text>
+
+  <!-- GENERATE_MSP_FORMAT -->
+  <g transform="translate(590, 854)">
+    <rect x="-95" y="-10" width="190" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(10, 10)" opacity="0.6"/>
+    <rect x="-95" y="-10" width="190" height="20" rx="4" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5" transform="translate(5, 5)" opacity="0.8"/>
+    <rect x="-95" y="-10" width="190" height="20" rx="4" fill="#fff" stroke="#00897B" stroke-width="2"/>
+    <rect x="-91" y="-8" width="182" height="16" rx="3" fill="#00897B"/>
+    <text x="0" y="3" text-anchor="middle" class="badge">GENERATE_MSP_FORMAT</text>
+  </g>
+  <text x="590" y="900" text-anchor="middle" class="sublabel">consensus spectral library</text>
+  <text x="590" y="914" text-anchor="middle" class="sublabel" font-style="italic">*.msp.gz per partition</text>
+  <text x="590" y="878" text-anchor="middle" class="parallel-note">× partitions</text>
+
+  <!-- Arrows from the two tail processes to the output cylinders -->
+  <line x1="310" y1="924" x2="310" y2="960" stroke="#F57C00" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-out)"/>
+  <line x1="590" y1="924" x2="590" y2="960" stroke="#F57C00" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-out)"/>
+
+  <!-- ══════ OUTPUTS ══════ -->
+  <g transform="translate(310, 976)">
+    <circle cx="0" cy="0" r="9" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+    <text x="0" y="-16" text-anchor="middle" class="label" fill="#F57C00">Cluster DB</text>
+  </g>
+  <g transform="translate(590, 976)">
+    <circle cx="0" cy="0" r="9" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+    <text x="0" y="-16" text-anchor="middle" class="label" fill="#F57C00">MSP Library</text>
   </g>
 
-  <!-- Output 2: MSP library -->
-  <g transform="translate(590, 810)">
-    <circle cx="0" cy="0" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
-    <text x="16" y="-2" class="label" fill="#F57C00">MSP Library</text>
-    <text x="16" y="14" class="sublabel">via GENERATE_MSP_FORMAT</text>
-    <text x="16" y="28" class="sublabel">*.msp.gz per partition</text>
+  <!-- ══════ LEGEND (bottom-left, no longer overlaps inputs) ══════ -->
+  <g transform="translate(60, 920)">
+    <rect x="0" y="0" width="200" height="80" rx="6" fill="#FAFAFA" stroke="#ECEFF1" stroke-width="1"/>
+    <text x="12" y="18" class="legend-title">LEGEND</text>
+    <rect x="14" y="27" width="14" height="10" rx="2" fill="#fff" stroke="#00897B" stroke-width="2"/>
+    <text x="36" y="36" class="legend-text">Process (runs once)</text>
+    <rect x="14" y="43" width="14" height="10" rx="2" fill="#FFCDD2" stroke="#D84315" stroke-width="1.5"/>
+    <text x="36" y="52" class="legend-text">Red shadows = parallel instances</text>
+    <line x1="14" y1="64" x2="28" y2="64" stroke="#9E9E9E" stroke-width="2.5" stroke-dasharray="5,3"/>
+    <text x="36" y="68" class="legend-text">Optional (<tspan font-family="'Courier New', monospace" font-size="9.5">--existing_cluster_db</tspan>)</text>
   </g>
 
-  <!-- Footer -->
-  <text x="410" y="866" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="10" fill="#B0BEC5">SpectrafUSE — Nextflow DSL2 · bigbio/spectrafuse</text>
+  <!-- Parallelism guide (bottom-right) -->
+  <g transform="translate(640, 920)">
+    <rect x="0" y="0" width="220" height="80" rx="6" fill="#FFF3E0" stroke="#FFE0B2" stroke-width="1"/>
+    <text x="12" y="18" class="legend-title" fill="#BF360C">PARALLELISM</text>
+    <text x="12" y="36" class="legend-text"><tspan class="parallel-note">× partitions</tspan> — one job per species/charge</text>
+    <text x="12" y="52" class="legend-text"><tspan class="parallel-note">× projects</tspan> — one job per QPX input</text>
+    <text x="12" y="68" class="legend-text"><tspan class="parallel-note" fill="#BF360C">× partitions × windows</tspan> — MaRaCluster fan-out</text>
+  </g>
 
 </svg>

--- a/docs/images/spectrafuse_workflow.svg
+++ b/docs/images/spectrafuse_workflow.svg
@@ -1,0 +1,181 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 880" width="820" height="880">
+  <defs>
+    <style>
+      .label     { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 13px; font-weight: 600; fill: #263238; }
+      .sublabel  { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10.5px; fill: #78909C; }
+      .badge     { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 8.5px; font-weight: 700; fill: #fff; letter-spacing: 0.4px; }
+      .opt-badge { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 8.5px; font-weight: 700; fill: #fff; letter-spacing: 0.4px; }
+      .caption   { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10.5px; font-style: italic; fill: #607D8B; }
+      .legend-title { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 11.5px; font-weight: 700; fill: #37474F; }
+      .legend-text  { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10.5px; fill: #607D8B; }
+    </style>
+    <marker id="arrow-main" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#00897B"/>
+    </marker>
+    <marker id="arrow-opt" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9E9E9E"/>
+    </marker>
+    <marker id="arrow-out" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#F57C00"/>
+    </marker>
+  </defs>
+
+  <rect width="820" height="880" fill="#ffffff"/>
+
+  <!-- ══════ TITLE ══════ -->
+  <text x="410" y="34" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="19" font-weight="bold" fill="#263238">SpectrafUSE Pipeline</text>
+  <text x="410" y="52" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="10.5" fill="#90A4AE">One workflow. --existing_cluster_db is just an optional extra input.</text>
+
+  <!-- ══════ LEGEND ══════ -->
+  <g transform="translate(620, 76)">
+    <rect x="-8" y="-14" width="192" height="88" rx="6" fill="#FAFAFA" stroke="#ECEFF1" stroke-width="1"/>
+    <text x="0" y="0" class="legend-title">LEGEND</text>
+    <circle cx="8" cy="18" r="6" fill="#00897B"/>
+    <text x="22" y="22" class="legend-text">Process</text>
+    <circle cx="8" cy="38" r="6" fill="none" stroke="#F57C00" stroke-width="2"/>
+    <text x="22" y="42" class="legend-text">Output</text>
+    <line x1="2" y1="58" x2="18" y2="58" stroke="#9E9E9E" stroke-width="2.5" stroke-dasharray="5,3"/>
+    <text x="22" y="62" class="legend-text">Optional (--existing_cluster_db)</text>
+  </g>
+
+  <!-- ══════════════════════════════════════════════════════════════════════════ -->
+  <!--                          INPUTS                                             -->
+  <!-- ══════════════════════════════════════════════════════════════════════════ -->
+
+  <!-- Primary input: QPX -->
+  <g transform="translate(410, 110)">
+    <circle cx="0" cy="0" r="9" fill="#1565C0" stroke="#fff" stroke-width="2"/>
+    <text x="16" y="-2" class="label" fill="#1565C0">QPX Parquet Projects</text>
+    <text x="16" y="14" class="sublabel">.psm.parquet · .run.parquet · .sample.parquet</text>
+  </g>
+
+  <!-- Optional input: existing cluster DB (left, dashed) -->
+  <g transform="translate(120, 110)">
+    <circle cx="0" cy="0" r="8" fill="none" stroke="#9E9E9E" stroke-width="2"/>
+    <text x="-14" y="-2" text-anchor="end" class="label" fill="#616161">--existing_cluster_db</text>
+    <text x="-14" y="14" text-anchor="end" class="sublabel">prior cluster_metadata.parquet</text>
+  </g>
+
+  <!-- ══════════════════════════════════════════════════════════════════════════ -->
+  <!--                          PER-SOURCE CONVERSION                              -->
+  <!-- ══════════════════════════════════════════════════════════════════════════ -->
+
+  <!-- QPX → PARQUET_TO_DAT -->
+  <line x1="410" y1="119" x2="410" y2="172" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+
+  <!-- existing_cluster_db → EXTRACT_REPS_DAT (dashed) -->
+  <line x1="120" y1="118" x2="120" y2="172" stroke="#9E9E9E" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="5,3" marker-end="url(#arrow-opt)"/>
+
+  <!-- EXTRACT_REPS_DAT (optional, dashed box) -->
+  <g transform="translate(120, 190)">
+    <circle cx="0" cy="0" r="9" fill="#ECEFF1" stroke="#9E9E9E" stroke-width="2" stroke-dasharray="3,2"/>
+    <rect x="-74" y="18" width="148" height="17" rx="3" fill="#9E9E9E"/>
+    <text x="0" y="31" text-anchor="middle" class="opt-badge">EXTRACT_REPS_DAT</text>
+    <text x="0" y="54" text-anchor="middle" class="sublabel">one consensus spectrum per cluster</text>
+    <text x="0" y="68" text-anchor="middle" class="sublabel" fill="#9E9E9E" font-style="italic">scan_title = rep:{cluster_id}</text>
+  </g>
+
+  <!-- PARQUET_TO_DAT -->
+  <g transform="translate(410, 190)">
+    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
+    <rect x="-74" y="18" width="148" height="17" rx="3" fill="#00897B"/>
+    <text x="0" y="31" text-anchor="middle" class="badge">PARQUET_TO_DAT</text>
+    <text x="0" y="54" text-anchor="middle" class="sublabel">~100 bytes/spectrum</text>
+    <text x="0" y="68" text-anchor="middle" class="sublabel">.dat + .scan_info + .scan_titles</text>
+  </g>
+
+  <!-- ══════════════════════════════════════════════════════════════════════════ -->
+  <!--                          SHARED CLUSTERING SPINE                            -->
+  <!-- ══════════════════════════════════════════════════════════════════════════ -->
+
+  <!-- Both conversions flow into CONCAT_DAT_FILES (center) -->
+  <path d="M 120,255 C 120,285 265,290 390,310" fill="none" stroke="#9E9E9E" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="5,3" marker-end="url(#arrow-opt)"/>
+  <line x1="410" y1="268" x2="410" y2="313" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+
+  <!-- Partition box subtle background -->
+  <rect x="120" y="325" width="580" height="445" rx="12" fill="#F5FBFA" stroke="#E0F2F1" stroke-width="1"/>
+  <text x="410" y="345" text-anchor="middle" class="caption">per partition — species / charge (or species / instrument / charge)</text>
+
+  <!-- CONCAT_DAT_FILES -->
+  <g transform="translate(410, 378)">
+    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
+    <rect x="-74" y="-33" width="148" height="17" rx="3" fill="#00897B"/>
+    <text x="0" y="-20" text-anchor="middle" class="badge">CONCAT_DAT_FILES</text>
+    <text x="16" y="-2" class="label">Concatenate .dat per charge</text>
+    <text x="16" y="14" class="sublabel">reps + new data, renumber scannr</text>
+  </g>
+  <line x1="410" y1="387" x2="410" y2="440" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+
+  <!-- SPLIT_MZ_WINDOWS -->
+  <g transform="translate(410, 458)">
+    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
+    <rect x="-74" y="-33" width="148" height="17" rx="3" fill="#00897B"/>
+    <text x="0" y="-20" text-anchor="middle" class="badge">SPLIT_MZ_WINDOWS</text>
+    <text x="16" y="-2" class="label">m/z windowing</text>
+    <text x="16" y="14" class="sublabel">300 Da windows, 1 Da overlap</text>
+  </g>
+  <line x1="410" y1="467" x2="410" y2="520" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+
+  <!-- RUN_MARACLUSTER_DAT (parallel fan-out) -->
+  <g transform="translate(410, 538)">
+    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
+    <circle cx="-22" cy="0" r="5" fill="#00897B" opacity="0.35"/>
+    <circle cx="-44" cy="0" r="4" fill="#00897B" opacity="0.2"/>
+    <circle cx="22" cy="0" r="5" fill="#00897B" opacity="0.35"/>
+    <circle cx="44" cy="0" r="4" fill="#00897B" opacity="0.2"/>
+    <rect x="-74" y="-33" width="148" height="17" rx="3" fill="#00897B"/>
+    <text x="0" y="-20" text-anchor="middle" class="badge">RUN_MARACLUSTER_DAT</text>
+    <text x="60" y="-2" class="label">MaRaCluster per window</text>
+    <text x="60" y="14" class="sublabel">parallel — one task per window</text>
+  </g>
+  <line x1="410" y1="547" x2="410" y2="600" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+
+  <!-- MERGE_MZ_WINDOWS -->
+  <g transform="translate(410, 618)">
+    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
+    <rect x="-74" y="-33" width="148" height="17" rx="3" fill="#00897B"/>
+    <text x="0" y="-20" text-anchor="middle" class="badge">MERGE_MZ_WINDOWS</text>
+    <text x="16" y="-2" class="label">Reconcile overlap zones</text>
+    <text x="16" y="14" class="sublabel">deterministic lowest-window wins</text>
+  </g>
+  <line x1="410" y1="627" x2="410" y2="680" stroke="#00897B" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrow-main)"/>
+
+  <!-- BUILD_CLUSTER_DB (or MERGE_INTO_EXISTING_DB) -->
+  <g transform="translate(410, 698)">
+    <circle cx="0" cy="0" r="9" fill="#00897B" stroke="#fff" stroke-width="2"/>
+    <rect x="-118" y="-33" width="236" height="17" rx="3" fill="#00897B"/>
+    <text x="0" y="-20" text-anchor="middle" class="badge">BUILD_CLUSTER_DB  /  MERGE_INTO_EXISTING_DB</text>
+    <text x="16" y="-2" class="label">Build cluster DB</text>
+    <text x="16" y="14" class="sublabel">resolve rep: cluster_ids; is_reused_cluster + source_datasets</text>
+  </g>
+
+  <!-- ══════════════════════════════════════════════════════════════════════════ -->
+  <!--                          OUTPUTS                                            -->
+  <!-- ══════════════════════════════════════════════════════════════════════════ -->
+
+  <!-- Split the flow into cluster DB + MSP outputs. GENERATE_MSP_FORMAT reads the
+       same merged-clusters + scan_titles, so show it as a sibling of the DB step. -->
+  <path d="M 410,707 C 410,750 290,770 230,790" fill="none" stroke="#F57C00" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-out)"/>
+  <path d="M 410,707 C 410,750 530,770 590,790" fill="none" stroke="#F57C00" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-out)"/>
+
+  <!-- Output 1: Cluster DB -->
+  <g transform="translate(230, 810)">
+    <circle cx="0" cy="0" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+    <text x="16" y="-2" class="label" fill="#F57C00">Cluster DB</text>
+    <text x="16" y="14" class="sublabel">cluster_metadata.parquet</text>
+    <text x="16" y="28" class="sublabel">psm_cluster_membership.parquet</text>
+    <text x="16" y="42" class="sublabel" fill="#F57C00" font-style="italic">partitioned by species/[instrument]/charge</text>
+  </g>
+
+  <!-- Output 2: MSP library -->
+  <g transform="translate(590, 810)">
+    <circle cx="0" cy="0" r="8" fill="none" stroke="#F57C00" stroke-width="2.5"/>
+    <text x="16" y="-2" class="label" fill="#F57C00">MSP Library</text>
+    <text x="16" y="14" class="sublabel">via GENERATE_MSP_FORMAT</text>
+    <text x="16" y="28" class="sublabel">*.msp.gz per partition</text>
+  </g>
+
+  <!-- Footer -->
+  <text x="410" y="866" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="10" fill="#B0BEC5">SpectrafUSE — Nextflow DSL2 · bigbio/spectrafuse</text>
+
+</svg>


### PR DESCRIPTION
This pull request updates the workflow overview section of the `README.md` to improve clarity and provide a more accessible summary of the SpectrafUSE pipeline. The main change is the replacement of the old ASCII workflow diagram and references to a design spec with a new visual SVG diagram and streamlined documentation links.

Documentation improvements:

* Replaced the ASCII workflow diagram and references to the design spec with a new SVG diagram (`docs/images/spectrafuse_workflow.svg`) for easier understanding and improved visual clarity.
* Consolidated and clarified file format documentation by linking directly to `docs/formats.md` for all pipeline file structures, replacing scattered explanations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow overview with an embedded visual diagram for improved clarity
  * Consolidated format documentation references into a single centralized resource
  * Removed outdated ASCII flow diagrams from the documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->